### PR TITLE
Add detailed text to themes

### DIFF
--- a/prototype/app/assets/sass/application.scss
+++ b/prototype/app/assets/sass/application.scss
@@ -69,6 +69,16 @@
   transition: width 1s;
 }
 
+.iai-inline-list {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: -0.5rem;
+  padding: 0;
+}
+.iai-inline-list li {
+  margin-left: 2rem;
+}
+
 /** QUESTION DETAIL PAGE **/
 .iai-filters {
   background-color: govuk-colour("light-grey");

--- a/prototype/app/data/session-data-defaults.js
+++ b/prototype/app/data/session-data-defaults.js
@@ -6,6 +6,17 @@ module.exports = {
     "Do you agree or disagree that all tobacco products, cigarette papers and herbal smoking products should be covered in the new legislation?",
     "Do you agree or disagree that warning notices in retail premises will need to be changed to read 'it is illegal to sell tobacco products to anyone born on or after 1 January 2009' when the law comes into effect?"
   ],
-  responses: []
+  themes: [
+    {"theme": "Preventing related illnesses starts now", value: 671},
+    {"theme": "... is becoming increasingly popular among young people who perceive it as a safer alternative.", value: 443},
+    {"theme": "Strong public opposition to change in sale ages", value: 163},
+    {"theme": "Limit children's access to products", value: 136},
+    {"theme": "Legalise ban on products for current and future generations", value: 127},
+    {"theme": "Age of sale for products should be changed to eradicate ...", value: 112},
+    {"theme": "It is harmful and should not be legally sold to anyone born after 1 January 2009", value: 105},
+    {"theme": "... and ... both need to be completely unavailable", value: 91},
+    {"theme": "Protect future generations from the harmful effects", value: 84},
+    {"theme": "The majority of respondents support raising the legal age of sale for products to 18 years old in the UK, believing it will help reduce peer pressure among young people", value: 81}
+  ]
 
 }

--- a/prototype/app/views/question-responses.html
+++ b/prototype/app/views/question-responses.html
@@ -35,32 +35,17 @@
           <input class="govuk-input govuk-input--width-10" id="keyword" name="keyword" type="text" value="{{data.keyword}}">
         </div>
 
-        {{ govukSelect({
-          id: "filter-theme",
-          name: "theme",
-          label: {
-            text: "Theme"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
-            },
-            {
-              value: "theme1",
-              text: "Theme 1"
-            },
-            {
-              value: "theme2",
-              text: "Theme 2"
-            },
-            {
-              value: "theme3",
-              text: "Theme 3"
-            }
-          ]
-        }) }}
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="theme">
+            Theme
+          </label>
+          <select class="govuk-select" id="filter-theme" name="theme">
+            <option value="all" {% if not data.theme or data.theme == "all" %}selected{% endif %}>All</option>
+            {% for item in data.themes %}
+              <option value="{{item.theme | urlencode}}" {% if data.theme == item.theme %}selected{% endif %}>{{item.theme}}</option>
+            {% endfor %}
+          </select>
+        </div>
 
         {{ govukSelect({
           id: "filter-opinion",

--- a/prototype/app/views/question-summary.html
+++ b/prototype/app/views/question-summary.html
@@ -274,7 +274,35 @@
       <tbody class="govuk-table__body">
         {% for item in themes %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{item.theme}}</th>
+            <td class="govuk-table__cell">
+              <details class="govuk-details govuk-!-margin-bottom-0">
+                <summary class="govuk-details__summary govuk-!-margin-top-1">
+                  <span class="govuk-details__summary-text">{{item.theme}}</span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p>The key argument expressed in the responses is that smoking is a major health issue in the UK and that strict measures need to be implemented to reduce its impact. Many respondents support the idea of raising the age of sale for tobacco products, with some seeing it as a way to 'Level Up' and reduce the burden on the NHS. The cost of smoking-related illnesses is also highlighted as a significant factor in the argument for stricter regulations.</p>
+                  <p>This theme has the following keywords:</p>
+                  <ul class="iai-inline-list">
+                    <li>nhs</li>
+                    <li>cost</li>
+                    <li>related</li>
+                    <li>money</li>
+                    <li>costs</li>
+                    <li>smoking</li>
+                    <li>health</li>
+                    <li>uk</li>
+                    <li>impact</li>
+                    <li>illnesses</li>
+                  </ul>
+                  <p>Example responses from this theme:</p>
+                  <ol>
+                    <li>"Smoking well recognised to be major impact on health, rates already falling, makes sense to go the next step. Will have great indirect benefits for healthcare also. Good protection against passive smoking, especially for children of parents who smoke."</li>
+                    <li>"I believe that the risks and ongoing NHS costs to the country outweigh the freedom of choice to start smoking"</li>
+                    <li>"The health, financial, and social implications of smoking are well documented and action is urgently needed to tackle the health of the nation. The NHS is under such strain, if we could reduce the number of smoking related health diseases it would have a big impact on resources. I believe we have a duty to protect future generations and especially young children from exposure to smoke."</li>
+                  </ol>
+                </div>
+              </details>
+            </td>
             <td class="govuk-table__cell">
               <span class="iai-bar">
                 <span class="iai-bar__value">{{item.value}}</span>

--- a/prototype/app/views/question-summary.html
+++ b/prototype/app/views/question-summary.html
@@ -51,9 +51,6 @@
       ],
       classes: "govuk-!-margin-bottom-4"
     }) }}
-
-    <a href="/question-responses?question-index={{data['question-index']}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all">View detailed responses &#8250;</a>
-
   </div>
   <div class="govuk-grid-column-one-third">
     <canvas data-yes="63" data-no="31" data-labels="true"></canvas>
@@ -245,21 +242,8 @@
   <div class="govuk-grid-column-two-thirds">
     {#<h2 class="govuk-heading-m">Prevalent themes</h2>#}
     {#<canvas id="prevalent-themes"></canvas>#}
-    
-    {% set themes = [
-      {"theme": "Preventing related illnesses starts now", value: 671},
-      {"theme": "... is becoming increasingly popular among young people who perceive it as a safer alternative.", value: 443},
-      {"theme": "Strong public opposition to change in sale ages", value: 163},
-      {"theme": "Limit children's access to products", value: 136},
-      {"theme": "Legalise ban on products for current and future generations", value: 127},
-      {"theme": "Age of sale for products should be changed to eradicate ...", value: 112},
-      {"theme": "It is harmful and should not be legally sold to anyone born after 1 January 2009", value: 105},
-      {"theme": "... and ... both need to be completely unavailable", value: 91},
-      {"theme": "Protect future generations from the harmful effects", value: 84},
-      {"theme": "The majority of respondents support raising the legal age of sale for products to 18 years old in the UK, believing it will help reduce peer pressure among young people", value: 81}
-    ] %}
 
-    {% set highestCount = themes[0].value %}
+    {% set highestCount = data.themes[0].value %}
 
     <table class="govuk-table">
       <caption class="govuk-table__caption govuk-table__caption--s">
@@ -272,7 +256,7 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        {% for item in themes %}
+        {% for item in data.themes %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
               <details class="govuk-details govuk-!-margin-bottom-0">
@@ -294,12 +278,10 @@
                     <li>impact</li>
                     <li>illnesses</li>
                   </ul>
-                  <p>Example responses from this theme:</p>
-                  <ol>
-                    <li>"Smoking well recognised to be major impact on health, rates already falling, makes sense to go the next step. Will have great indirect benefits for healthcare also. Good protection against passive smoking, especially for children of parents who smoke."</li>
-                    <li>"I believe that the risks and ongoing NHS costs to the country outweigh the freedom of choice to start smoking"</li>
-                    <li>"The health, financial, and social implications of smoking are well documented and action is urgently needed to tackle the health of the nation. The NHS is under such strain, if we could reduce the number of smoking related health diseases it would have a big impact on resources. I believe we have a duty to protect future generations and especially young children from exposure to smoke."</li>
-                  </ol>
+                  <a href="/question-responses?question-index={{data['question-index']}}&keyword=&theme={{item.theme | urlencode}}&opinion=all&location=all&age=all&capacity=all">
+                    View detailed responses for this theme &#8250;
+                    <span class="govuk-visually-hidden"> - {{item.theme}}</span>
+                  </a>
                 </div>
               </details>
             </td>


### PR DESCRIPTION
## Context
On the question summary page, there are a list of Prevalent themes along with the number of respondents. Following feedback from Jonah, this also needs to show a more detailed description for each theme.

## Changes proposed in this pull request
Each theme is now using the gov.uk details component. When clicked, this expands to show the detailed description, along with keywords and a link to responses. It's just using static text for now so it's the same description for each theme.

### Before
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/af38bbb1-7697-4533-9855-70b34121ff7e)

### After
#### Closed:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/3c25c04c-0a5b-401f-b289-41eb2b6c9ddf)
#### Open:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/7a17c29a-0e2b-4aa2-88ae-60484e03ab24)

## Guidance to review
Visit the `/question-summary` page and click on the theme text.
