### PR TITLE
Hardcode a page title in the prototype

### DIFF
--- a/prototype/app/views/index.html
+++ b/prototype/app/views/index.html
@@ -6,6 +6,8 @@
 
 {% set pageName="Home" %}
 
+{% block pageTitle %}Consultation on Fourth Sector Pathfinders{% endblock %}
+
 {% block content %}
 
 <script src="https://cdn.anychart.com/releases/8.0.0/js/anychart-base.min.js"></script>

--- a/prototype/app/views/layouts/main.html
+++ b/prototype/app/views/layouts/main.html
@@ -7,7 +7,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Consultations tool – GOV.UK Prototype Kit</title>
+    <title>{% block pageTitle %}{% endblock %} – Consultations Analyser - GOV.UK Prototype Kit</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">

--- a/prototype/app/views/layouts/main.html
+++ b/prototype/app/views/layouts/main.html
@@ -7,7 +7,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{% block pageTitle %}{% endblock %} – GOV.UK Prototype Kit</title>
+    <title>Consultations tool – GOV.UK Prototype Kit</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
@@ -108,14 +108,14 @@ serviceUrl: "/"
                     />
                 </svg>
                 <span class="govuk-footer__licence-description">
-            
+
               All content is available under the
               <a
                       class="govuk-footer__link"
                       href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
                       rel="license"
               >Open Government Licence v3.0</a>, except where otherwise stated
-            
+
           </span>
             </div>
             <div class="govuk-footer__meta-item">

--- a/prototype/app/views/question-responses.html
+++ b/prototype/app/views/question-responses.html
@@ -8,6 +8,8 @@
 
 {% set pageName="Home" %}
 
+{% block pageTitle %}Responses to question {{data["question-index"]|int + 1}}{% endblock %}
+
 {% block beforeMain %}
   {{ govukBackLink({
     text: "Back to all questions",

--- a/prototype/app/views/question-summary.html
+++ b/prototype/app/views/question-summary.html
@@ -8,6 +8,8 @@
 
 {% set pageName="Home" %}
 
+{% block pageTitle %}Question Summary for question {{data["question-index"]|int + 1}}{% endblock %}
+
 {% block beforeMain %}
   {{ govukBackLink({
     text: "Back to all questions",

--- a/prototype/app/views/respondent.html
+++ b/prototype/app/views/respondent.html
@@ -6,6 +6,8 @@
 
 {% set pageName="Home" %}
 
+{% block pageTitle %}Respondent A{% endblock %}
+
 {% block beforeMain %}
   {{ govukBackLink({
     text: "Back to question",


### PR DESCRIPTION
## Context

The tab currently starts with a `-` which is unsightly

## Changes proposed in this pull request

Hardcode the title, which is good enough for now.

## Guidance to review

Does it look right

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo