### PR TITLE
Add dummy ML pipeline as a management command.

### DIFF
--- a/consultation_analyser/consultations/management/commands/run_ml_pipeline.py
+++ b/consultation_analyser/consultations/management/commands/run_ml_pipeline.py
@@ -1,0 +1,23 @@
+# Currently a placeholder for command to run ML pipeline
+from django.core.management.base import BaseCommand
+
+from consultation_analyser.consultations import models
+
+
+class Command(BaseCommand):
+    help = "Run the machine learning pipeline to generate themes for the consultation"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--consultation_slug", action="store", help="The slug for the consultation", type=str)
+
+    def handle(self, *args, **options):
+        if options["consultation_slug"]:
+            try:
+                consultation = models.Consultation.objects.get(slug=options["consultation_slug"])
+                # TODO - this is to be replaced with the actual ML pipeline
+                dummy_message = f"This is a placeholder for running the ML pipeline for consultation with name '{consultation.name}'"
+                self.stdout.write(dummy_message)
+            except models.Consultation.DoesNotExist:
+                self.stdout.write("You need to enter a valid slug for a consultation")
+        else:
+            self.stdout.write("You need to enter the slug for a consultation")

--- a/tests/unit/test_run_ml_pipeline.py
+++ b/tests/unit/test_run_ml_pipeline.py
@@ -1,0 +1,29 @@
+# Tests for dummy ML pipeline
+from io import StringIO
+
+import pytest
+
+from consultation_analyser.consultations.models import Consultation
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+def test_command_with_valid_slug():
+    Consultation.objects.create(slug="test-consultation", name="Test Consultation")
+    out = StringIO()
+    call_command("run_ml_pipeline", consultation_slug="test-consultation", stdout=out)
+    assert "Test Consultation" in out.getvalue(), out.getvalue()
+
+
+@pytest.mark.django_db
+def test_command_with_invalid_slug():
+    out = StringIO()
+    call_command("run_ml_pipeline", consultation_slug="invalid-slug", stdout=out)
+    assert "enter a valid slug" in out.getvalue(), out.getvalue()
+
+
+@pytest.mark.django_db
+def test_command_without_slug():
+    out = StringIO()
+    call_command("run_ml_pipeline", stdout=out)
+    assert "enter the slug" in out.getvalue(), out.getvalue()


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Adding a dummy command as a placeholder for the ML pipeline.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Adding a dummy management command that prints a statement instead of running the ML pipeline (ML pipeline to follow).

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Run the command with/without passing in the slug of a consultation.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
The start of building an ML pipeline: https://technologyprogramme.atlassian.net/browse/CON-47 (does not complete this ticket!)

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo