### PR TITLE
Feature/responses page

### DIFF
--- a/consultation_analyser/consultations/jinja2/show_responses.html
+++ b/consultation_analyser/consultations/jinja2/show_responses.html
@@ -1,0 +1,188 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+{%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
+
+{% set page_title = "Responses - dummy page" %}
+
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">{{ page_title }}</h1>
+      <p class="govuk-body">{{ question.text }}</p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row govuk-!-margin-top-5">
+
+    <div class="govuk-grid-column-one-third">
+      <div class="iai-filters govuk-!-margin-bottom-5">
+        <h2 class="govuk-heading-m">Filters</h2>
+        <form>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="event-name">Keyword search</label>
+            <input class="govuk-input govuk-input--width-10" id="keyword" name="keyword" type="text" value="{{applied_filters.keyword}}">
+          </div>
+
+          <div class="govuk-form-group">
+              <label class="govuk-label" for="theme">
+                Theme
+              </label>
+              <select class="govuk-select" id="theme" name="theme">
+                <option {% if applied_filters.theme == "All" %}selected{% endif %}>All</option>
+                {% for theme in themes_for_question %}
+                  <option value="{{ theme.id }}" {% if applied_filters.theme|string == theme.id|string %}selected{% endif %}>{{ theme.label }}</option>
+                {% endfor %}
+                <option {% if applied_filters.theme == "No theme" %}selected{% endif %}>No theme</option>
+              </select>
+            </div>
+
+          {% if question.multiple_choice_options %}
+            <div class="govuk-form-group">
+              <label class="govuk-label" for="opinion">
+                Opinion
+              </label>
+              <select class="govuk-select" id="opinion" name="opinion">
+                <option {% if applied_filters.opinion == "All" %}selected{% endif %}>All</option>
+                {% for option in question.multiple_choice_options %}
+                  <option {% if applied_filters.opinion == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          {% endif %}
+
+          {{ govukButton({
+            "text": "Apply filters",
+            "classes": "govuk-!-margin-bottom-2"
+          }) }}
+          <div class="govuk-!-padding-2">
+            <a class="govuk-body" href="?">Clear filters</a>
+          </div>
+
+        </form>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Responses</h2>
+          <span class="iai-table-subhead govuk-!-margin-top-1">(Showing <strong>{{ responses|length }}</strong> of <strong>{{ total_responses }}</strong> responses)</span>
+        </caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            {% if question.multiple_choice_options %}
+              <th scope="col" class="govuk-table__header">Multiple choice</th>
+            {% endif %}
+            <th scope="col" class="govuk-table__header">Free text</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for response in responses %}
+            <tr class="govuk-table__row govuk-body-s">
+              {% if question.multiple_choice_options %}
+                <td class="govuk-table__cell">
+                  {{ response.multiple_choice_responses }}
+                </td>
+              {% endif %}
+              <td class="govuk-table__cell">
+                {{ response.free_text }}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+
+      {# Pagination #}
+      <nav class="govuk-pagination" role="navigation" aria-label="Pagination">
+
+        {% set filters = namespace(str="") %}
+        {% for key, value in applied_filters.items() %}
+          {% set filters.str = filters.str + "&" + key + "=" + value %}
+        {% endfor %}
+
+        {% if pagination.number > 1 %}
+          <div class="govuk-pagination__prev">
+            <a class="govuk-link govuk-pagination__link" href="?page={{ pagination.number - 1 }}{{ filters.str }}" rel="prev">
+              <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+              </svg>
+              <span class="govuk-pagination__link-title">
+                Previous<span class="govuk-visually-hidden"> page</span>
+              </span>
+            </a>
+          </div>
+        {% endif %}
+
+        <ul class="govuk-pagination__list">
+
+          {% if pagination.number > 2 %}
+            <li class="govuk-pagination__item">
+              <a class="govuk-link govuk-pagination__link" href="?page=1{{ filters.str }}" aria-label="Page 1">
+                1
+              </a>
+            </li>
+            <li class="govuk-pagination__item govuk-pagination__item--ellipses">
+              &ctdot;
+            </li>
+          {% endif %}
+
+          {% if pagination.has_previous() %}
+            <li class="govuk-pagination__item">
+              <a class="govuk-link govuk-pagination__link" href="?page={{ pagination.previous_page_number() }}{{ filters.str }}" aria-label="Page {{ pagination.previous_page_number() }}">
+                {{ pagination.previous_page_number() }}
+              </a>
+            </li>
+          {% endif %}
+          <li class="govuk-pagination__item govuk-pagination__item--current">
+            <a class="govuk-link govuk-pagination__link" href="?page={{ pagination.number }}{{ filters.str }}" aria-label="Page {{ pagination.number }}" aria-current="page">
+              {{ pagination.number }}
+            </a>
+          </li>
+
+          {% if pagination.has_next() %}
+            <li class="govuk-pagination__item">
+              <a class="govuk-link govuk-pagination__link" href="?page={{ pagination.next_page_number() }}{{ filters.str }}" aria-label="Page {{ pagination.next_page_number() }}">
+                {{ pagination.next_page_number() }}
+              </a>
+            </li>
+          {% endif %}
+
+          {% if pagination.paginator.num_pages > pagination.number + 1 %}
+            <li class="govuk-pagination__item govuk-pagination__item--ellipses">
+              &ctdot;
+            </li>
+            <li class="govuk-pagination__item">
+              <a class="govuk-link govuk-pagination__link" href="?page={{ pagination.paginator.num_pages }}{{ filters.str }}" aria-label="Page {{ pagination.paginator.num_pages }}">
+                {{ pagination.paginator.num_pages }}
+              </a>
+            </li>
+          {% endif %}
+
+        </ul>
+
+        {% if pagination.has_next() %}
+          <div class="govuk-pagination__next">
+            <a class="govuk-link govuk-pagination__link" href="?page={{ pagination.next_page_number() }}{{ filters.str }}" rel="next">
+              <span class="govuk-pagination__link-title">
+                Next<span class="govuk-visually-hidden"> page</span>
+              </span>
+              <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
+                <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+              </svg>
+            </a>
+          </div>
+        {% endif %}
+
+      </nav>
+
+
+    </div>
+
+  </div>
+
+{% endblock %}

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -10,4 +10,8 @@ urlpatterns = [
         questions.show,
         name="show_question",
     ),
+    path(
+        "consultations/<str:consultation_slug>/sections/<str:section_slug>/responses/<str:question_slug>",
+        views.show_responses,
+    ),
 ]

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -12,6 +12,6 @@ urlpatterns = [
     ),
     path(
         "consultations/<str:consultation_slug>/sections/<str:section_slug>/responses/<str:question_slug>",
-        views.show_responses,
+        questions.show_responses,
     ),
 ]

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -3,6 +3,7 @@ from django.http import HttpRequest
 from django.shortcuts import render
 
 from .. import models
+from django.core.paginator import Paginator
 
 
 def show(request: HttpRequest, consultation_slug: str, section_slug: str, question_slug: str):
@@ -34,3 +35,47 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
         "multiple_choice": multiple_choice,
     }
     return render(request, "show_question.html", context)
+
+
+def get_applied_filters(request: HttpRequest):
+    return {
+        "keyword": request.GET.get("keyword", ""),
+        "theme": request.GET.get("theme", "All"),
+        "opinion": request.GET.get("opinion", "All"),
+    }
+
+
+def get_filtered_responses(question: models.Question, applied_filters):
+    queryset = models.Answer.objects.filter(question=question, free_text__icontains=applied_filters["keyword"])
+    if applied_filters["theme"] != "All" and applied_filters["theme"] != "No theme":
+        queryset = queryset.filter(theme=applied_filters["theme"])
+    # TO DO: handle answers with "No theme"
+    if applied_filters["opinion"] != "All":
+        queryset = queryset.filter(multiple_choice_responses=applied_filters["opinion"])
+    return queryset
+
+
+def show_responses(request: HttpRequest, consultation_slug: str, section_slug: str, question_slug: str):
+    question = models.Question.objects.get(
+        slug=question_slug, section__slug=section_slug, section__consultation__slug=consultation_slug
+    )
+    themes_for_question = models.Theme.objects.filter(answer__question=question)
+    total_responses = models.Answer.objects.filter(question=question).count()
+    applied_filters = get_applied_filters(request)
+    responses = get_filtered_responses(question, applied_filters)
+
+    # pagination
+    pagination = Paginator(responses, 5)
+    page_index = request.GET.get("page", "1")
+    current_page = pagination.page(page_index)
+    paginated_responses = current_page.object_list
+
+    context = {
+        "question": question,
+        "responses": paginated_responses,
+        "total_responses": total_responses,
+        "applied_filters": applied_filters,
+        "themes_for_question": themes_for_question,
+        "pagination": current_page,
+    }
+    return render(request, "show_responses.html", context)

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -5,6 +5,8 @@ from django.shortcuts import render
 from .. import models
 from django.core.paginator import Paginator
 
+from .. import models
+
 
 def show(request: HttpRequest, consultation_slug: str, section_slug: str, question_slug: str):
     question = models.Question.objects.get(

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -1,9 +1,7 @@
+from django.core.paginator import Paginator
 from django.db.models import Count, Max
 from django.http import HttpRequest
 from django.shortcuts import render
-
-from .. import models
-from django.core.paginator import Paginator
 
 from .. import models
 

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -15,7 +15,7 @@ $iai-colour-pink: #b62777;
 }
 
 
-/** QUESTION OVERVIEW PAGE **/
+/** QUESTION SUMMARY PAGE **/
 
 .govuk-table__cell:has(.iai-bar) {
     padding: 0.25rem 0;
@@ -77,3 +77,24 @@ $iai-colour-pink: #b62777;
     display: flex;
     gap: 1.25rem;
 }
+
+/** RESPONSES PAGE **/
+
+.iai-filters {
+    background-color: govuk-colour("light-grey");
+    padding: 1rem;
+  }
+  @media (min-width: 641px) {
+    .iai-filters {
+      max-width: 14rem;
+    }
+  }
+  .iai-filters .govuk-form-group {
+    /*margin-bottom: 1.5rem;*/
+  }
+
+  .iai-table-subhead {
+    display: block;
+    font-size: 1.125rem;
+    font-weight: 100;
+  }

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -49,6 +49,10 @@ class ConsultationFactory(factory.django.DjangoModelFactory):
                 with_question=True,
                 with_question__with_answer=kwargs.get("with_answer"),
                 with_question__with_multiple_choice=kwargs.get("with_multiple_choice"),
+<<<<<<< HEAD
+=======
+                with_question__with_free_text=kwargs.get("with_free_text"),
+>>>>>>> 3e52f6e (Build responses page)
             )
 
 
@@ -71,13 +75,17 @@ class SectionFactory(factory.django.DjangoModelFactory):
                 section=section,
                 with_answer=kwargs.get("with_answer"),
                 with_multiple_choice=kwargs.get("with_multiple_choice"),
+<<<<<<< HEAD
+=======
+                with_free_text=kwargs.get("with_free_text"),
+>>>>>>> 3e52f6e (Build responses page)
             )
 
 
 class QuestionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Question
-        skip_postgeneration_save = True
+        skip_postgeneration_save = False
 
     text = factory.LazyAttribute(lambda o: o.question["text"])
     slug = factory.LazyAttribute(lambda o: o.question["slug"])
@@ -97,7 +105,19 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     def with_multiple_choice(question, creation_strategy, value, **kwargs):
         if value is True and question.multiple_choice_options is None:
             question.multiple_choice_options = default_multiple_choice_options
+<<<<<<< HEAD
             question.save()
+=======
+
+    @factory.post_generation
+    def with_free_text(question, creation_strategy, value, **kwargs):
+        if value is True:
+            AnswerFactory(
+                question=question,
+                with_multiple_choice=kwargs.get("with_multiple_choice"),
+                with_free_text=kwargs.get("with_free_text"),
+            )
+>>>>>>> 3e52f6e (Build responses page)
 
 
 class ConsultationResponseFactory(factory.django.DjangoModelFactory):
@@ -140,4 +160,10 @@ class AnswerFactory(factory.django.DjangoModelFactory):
     def with_multiple_choice(answer, creation_strategy, value, **kwargs):
         if answer.multiple_choice_responses is None:
             answer.multiple_choice_responses = random.choice(default_multiple_choice_options)
+            answer.save()
+
+    @factory.post_generation
+    def with_free_text(answer, creation_strategy, value, **kwargs):
+        if answer.free_text is None:
+            answer.free_text = "This is a sample free-text response"
             answer.save()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -49,10 +49,7 @@ class ConsultationFactory(factory.django.DjangoModelFactory):
                 with_question=True,
                 with_question__with_answer=kwargs.get("with_answer"),
                 with_question__with_multiple_choice=kwargs.get("with_multiple_choice"),
-<<<<<<< HEAD
-=======
                 with_question__with_free_text=kwargs.get("with_free_text"),
->>>>>>> 3e52f6e (Build responses page)
             )
 
 
@@ -75,10 +72,7 @@ class SectionFactory(factory.django.DjangoModelFactory):
                 section=section,
                 with_answer=kwargs.get("with_answer"),
                 with_multiple_choice=kwargs.get("with_multiple_choice"),
-<<<<<<< HEAD
-=======
                 with_free_text=kwargs.get("with_free_text"),
->>>>>>> 3e52f6e (Build responses page)
             )
 
 
@@ -100,14 +94,13 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     def with_answer(question, creation_strategy, value, **kwargs):
         if value is True:
             AnswerFactory(question=question, with_multiple_choice=kwargs.get("with_multiple_choice"))
+            question.save()
 
     @factory.post_generation
     def with_multiple_choice(question, creation_strategy, value, **kwargs):
         if value is True and question.multiple_choice_options is None:
             question.multiple_choice_options = default_multiple_choice_options
-<<<<<<< HEAD
             question.save()
-=======
 
     @factory.post_generation
     def with_free_text(question, creation_strategy, value, **kwargs):
@@ -117,7 +110,7 @@ class QuestionFactory(factory.django.DjangoModelFactory):
                 with_multiple_choice=kwargs.get("with_multiple_choice"),
                 with_free_text=kwargs.get("with_free_text"),
             )
->>>>>>> 3e52f6e (Build responses page)
+            question.save()
 
 
 class ConsultationResponseFactory(factory.django.DjangoModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -93,8 +93,8 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     @factory.post_generation
     def with_answer(question, creation_strategy, value, **kwargs):
         if value is True:
-            AnswerFactory(question=question, with_multiple_choice=kwargs.get("with_multiple_choice"))
-            question.save()
+            answer = AnswerFactory(question=question, with_multiple_choice=kwargs.get("with_multiple_choice"))
+            answer.save()
 
     @factory.post_generation
     def with_multiple_choice(question, creation_strategy, value, **kwargs):
@@ -105,12 +105,12 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     @factory.post_generation
     def with_free_text(question, creation_strategy, value, **kwargs):
         if value is True:
-            AnswerFactory(
+            answer = AnswerFactory(
                 question=question,
                 with_multiple_choice=kwargs.get("with_multiple_choice"),
                 with_free_text=kwargs.get("with_free_text"),
             )
-            question.save()
+            answer.save()
 
 
 class ConsultationResponseFactory(factory.django.DjangoModelFactory):

--- a/tests/integration/test_question_pages.py
+++ b/tests/integration/test_question_pages.py
@@ -25,7 +25,6 @@ def test_get_question_summary_page(django_app):
         assert keyword in page_content
 
     if question.multiple_choice_options:
-        print("Has multiple choice")
         for option in question.multiple_choice_options:
             assert option in page_content
 

--- a/tests/integration/test_question_pages.py
+++ b/tests/integration/test_question_pages.py
@@ -24,8 +24,10 @@ def test_get_question_summary_page(django_app):
     for keyword in answer.theme.keywords:
         assert keyword in page_content
 
-    for option in question.multiple_choice_options:
-        assert option in page_content
+    if question.multiple_choice_options:
+        print("Has multiple choice")
+        for option in question.multiple_choice_options:
+            assert option in page_content
 
     percentages = re.findall(r"\d+%", page_content)
     count = 0

--- a/tests/integration/test_responses_pages.py
+++ b/tests/integration/test_responses_pages.py
@@ -1,0 +1,45 @@
+import pytest
+import html
+
+
+from tests.factories import ConsultationFactory
+
+
+@pytest.mark.django_db
+def test_get_question_responses_page(django_app):
+    consultation = ConsultationFactory(
+        with_question=True,
+        with_question__with_answer=True,
+        with_question__with_multiple_choice=True,
+        with_question__with_free_text=True,
+    )
+    section = consultation.section_set.first()
+    question = section.question_set.first()
+    answers = question.answer_set.all()
+    question_responses_url = f"/consultations/{consultation.slug}/sections/{section.slug}/responses/{question.slug}"
+    responses_page = django_app.get(question_responses_url)
+    page_content = html.unescape(str(responses_page.content))
+
+    assert "Responses" in page_content
+    assert f"{question.text}" in page_content
+
+    # Check responses appear
+    answer_loop_range = min(4, len(answers))
+    for i in range(answer_loop_range):
+        assert f"{answers[i].free_text}" in page_content
+        assert f"{answers[i].theme.label}" in page_content
+        assert f"{answers[i].multiple_choice_responses}" in page_content
+
+    # Opinions should appear in filter select-box
+    for option in question.multiple_choice_options:
+        assert option in page_content
+
+    # Check keyword filtering
+    first_word_of_answer = answers[0].free_text.split()[0]
+    keywords = ["ThisWordWontAppear", first_word_of_answer]
+    for keyword in keywords:
+        responses_page = django_app.get(f"{question_responses_url}?keyword={keyword}")
+        page_content = html.unescape(str(responses_page.content))
+        assert keyword in page_content
+        if keyword == "ThisWordWontAppear":
+            assert f"Showing <strong>0</strong> of <strong>{len(answers)}</strong> reponses"

--- a/tests/integration/test_responses_pages.py
+++ b/tests/integration/test_responses_pages.py
@@ -1,6 +1,6 @@
-import pytest
 import html
 
+import pytest
 
 from tests.factories import ConsultationFactory
 


### PR DESCRIPTION
## Context

This is the creation of the responses explorer. Jira ticket: https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418/backlog?selectedIssue=CON-28

## Changes proposed in this pull request
* The creation of this page:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/a807d611-9ce1-4789-ad51-401032a04d79)
* Building integration tests

## Guidance to review
* Visit `/consultations/administration-no/sections/early-especially/responses/favorite-cadbury-chocolate-bar` and check it looks as per the above screenshot
* Test the pagination (I've set this to 5 per page for now, to allow for testing. I imagine we'll want to increase this to at least 10 once we have more data)
* Test the filtering

## Notes
* There will be more filters once we have respondent data
* This branch is based off `feature/question-summary-data`, so this shouldn't be merged into `main` before that one is.