### PR TITLE
Reload gunicorn in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ migrate: ## Apply migrations
 
 .PHONY: serve
 serve: ## Run the server
-	poetry run gunicorn -c consultation_analyser/gunicorn.py consultation_analyser.wsgi
+	poetry run gunicorn --reload --workers=1 -c consultation_analyser/gunicorn.py consultation_analyser.wsgi
 
 .PHONY: test
 test: ## Run the tests


### PR DESCRIPTION
## Context

`gunicorn` wasn't reloading. This was confusing.

## Changes proposed in this pull request

Change the invocation in the `Makefile` so it includes the `--reload` flag. Also set `--workers=1` because that's simpler for dev too.

This is what it looks like when editing `settings/base.py` with and without this change:

**Before**
<img width="792" alt="Screenshot 2024-03-29 at 21 42 24" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/b3a6f1b7-b823-4eb7-8e2f-a6e8c9e33487">

**After**
<img width="1295" alt="Screenshot 2024-03-29 at 21 41 30" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/7c293498-544a-4792-9ee1-cf02684143d1">

## Guidance to review

`make serve` should continue to work!

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo