### PR TITLE
Break up `views.py` in a subfolder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: 1.7.6
     hooks:
     -   id: bandit
-        args: [ "-c", "pyproject.toml", "-ll", "-r", "." ]
+        args: [ "-c", "pyproject.toml", "-ll", "-r", "consultation_analyser" ]
         additional_dependencies: [ "bandit[toml]" ]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -1,12 +1,12 @@
 from django.urls import path
 
-from . import views
+from .views import questions, pages
 
 urlpatterns = [
-    path("", views.home),
+    path("", pages.home),
     path(
         "consultations/<str:consultation_slug>/sections/<str:section_slug>/questions/<str:question_slug>",
-        views.show_question,
+        questions.show,
         name="show_question",
     ),
 ]

--- a/consultation_analyser/consultations/views/pages.py
+++ b/consultation_analyser/consultations/views/pages.py
@@ -1,0 +1,9 @@
+from django.shortcuts import render
+from django.http import HttpRequest
+from .. import models
+
+
+def home(request: HttpRequest):
+    questions = models.Question.objects.all().order_by("id")[:10]
+    context = {"questions": questions}
+    return render(request, "home.html", context)

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -1,16 +1,10 @@
 from django.shortcuts import render
 from django.http import HttpRequest
 from django.db.models import Count, Max
-from . import models
+from .. import models
 
 
-def home(request: HttpRequest):
-    questions = models.Question.objects.all().order_by("id")[:10]
-    context = {"questions": questions}
-    return render(request, "home.html", context)
-
-
-def show_question(request: HttpRequest, consultation_slug: str, section_slug: str, question_slug: str):
+def show(request: HttpRequest, consultation_slug: str, section_slug: str, question_slug: str):
     question = models.Question.objects.get(
         slug=question_slug, section__slug=section_slug, section__consultation__slug=consultation_slug
     )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -76,7 +76,7 @@ class SectionFactory(factory.django.DjangoModelFactory):
 class QuestionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Question
-        skip_postgeneration_save = False
+        skip_postgeneration_save = True
 
     text = factory.LazyAttribute(lambda o: o.question["text"])
     slug = factory.LazyAttribute(lambda o: o.question["slug"])
@@ -96,6 +96,7 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     def with_multiple_choice(question, creation_strategy, value, **kwargs):
         if value is True and question.multiple_choice_options is None:
             question.multiple_choice_options = default_multiple_choice_options
+            question.save()
 
 
 class ConsultationResponseFactory(factory.django.DjangoModelFactory):
@@ -118,6 +119,7 @@ class ThemeFactory(factory.django.DjangoModelFactory):
 class AnswerFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Answer
+        skip_postgeneration_save = True
 
     multiple_choice_responses = factory.LazyAttribute(
         lambda o: FakeConsultationData().get_multiple_choice_answer(o.question.slug)
@@ -137,3 +139,4 @@ class AnswerFactory(factory.django.DjangoModelFactory):
     def with_multiple_choice(answer, creation_strategy, value, **kwargs):
         if answer.multiple_choice_responses is None:
             answer.multiple_choice_responses = random.choice(default_multiple_choice_options)
+            answer.save()


### PR DESCRIPTION
## Context

The `views.py` file will soon deal with the homepage, the consultations page, the question page and the schema page. Break it up before it becomes too painful to do so.

## Changes proposed in this pull request

- break up `views.py` - no tests change because behaviour is identical 💪 

plus 2 quality of life improvements:
- change `bandit` invocation so it doesn't try to run on the whole of `node_modules` every time
- silence some deprecation warnings that @KevinEtchells and I accidentally incurred during #36 

## Guidance to review

Does this make sense and is there any reason not to do it?

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo