### PR TITLE
DRAFT: Use ConsultationProcessingRun and env vars

### DIFF
--- a/consultation_analyser/consultations/processing.py
+++ b/consultation_analyser/consultations/processing.py
@@ -1,0 +1,74 @@
+from abc import ABC, abstractmethod
+import environ
+from uuid import uuid4
+
+env = environ.Env()
+
+class LabellingLLM(ABC):
+    @abstractmethod
+    def assign_label(themes):
+        return
+
+class SagemakerLabellingLLM(LabellingLLM):
+    def __init__(self):
+        # do some sagemaker waking up
+        pass
+
+    def assign_label(self, themes):
+        # make a sagemaker call with the themes
+        pass
+
+class DummyLabellingLLM(LabellingLLM):
+    # no __init__ because there's no setup
+
+    # this is the same method as above with different impl
+    def assign_label(self, themes):
+        return ",".join(themes) # or whatever
+
+class ConsultationProcessingRun: # dummy django model for illustration process
+    def __init__(self, slug, start_time):
+        pass
+
+    def find(pk):
+        pass
+
+    def save(self):
+        pass
+
+    def mark_completed(self):
+        pass
+
+# function for the view to call. will return the uuid of the ConsultationProcessingRun
+def send_consultation_to_be_processed(consultation_slug: str) -> uuid4:
+    # this would have a foreign key to the consultation and a start time
+    processing_run = ConsultationProcessingRun(consultation_slug, start_time='current time').save()
+    if env.str("CONSULTATION_PROCESSING_BACKEND").upper() == 'AWS_BATCH':
+        send_consultation_processing_to_aws_batch(processing_run.id)
+        return processing_run.id # the view can redirect us to the run's show page which will be "in progess"
+    else:
+        # the view can redirect us to the run's show page which will be
+        # done by the time we get there
+        return process_consultation(processing_run.id)
+
+def send_consultation_processing_to_aws_batch(processing_run_id: uuid4) -> None:
+    # effectful function sending the API call to batch
+    pass
+
+def assign_themes(consultation_slug) -> None:
+    pass
+
+def assign_labels(consultation_slug, llm) -> None:
+    pass
+
+def process_consultation(processing_run_id) -> None:
+    if env.str("LABELLING_BACKEND").upper() == "SAGEMAKER":
+        llm = SagemakerLabellingLLM()
+    else:
+        llm = DummyLabellingLLM()
+
+    do the actual work, e.g.
+    assign_themes(consultation_slug)
+    assign_labels(consultation_slug, llm)
+
+    run = ConsultationProcessingRun.find(pk=processing_run_id)
+    run.mark_completed()

--- a/consultation_analyser/consultations/views.py
+++ b/consultation_analyser/consultations/views.py
@@ -3,11 +3,19 @@ from django.http import HttpRequest
 from django.db.models import Count, Max
 from . import models
 
+from consultation_analyser.consultations.processing import send_consultation_to_be_processed
 
 def home(request: HttpRequest):
     questions = models.Question.objects.all().order_by("id")[:10]
     context = {"questions": questions}
     return render(request, "home.html", context)
+
+
+def show_consultation(request, consultation_slug: str):
+    # assume this is the view that shows a consultation
+    # on the page there is a button to process the consultation
+    if request.method == "POST": # or whatever to determine we're processing
+        send_consultation_to_be_processed(consultation_slug)
 
 
 def show_question(request: HttpRequest, consultation_slug: str, section_slug: str, question_slug: str):


### PR DESCRIPTION
- add ConsultationProcessingRun to track the progress of the run. this makes sync/async simpler (async, i.e. batch, will leave the run in a "pending" state for longer and we can render a page to that effect (even with a progress bar!) - when it's done we can render the "finished" page which is what we'll see if we do everything inline)
- make the processing backend explicitly configurable via an ENV var - this feels much less magical than "if we're on AWS then use Batch"
- do the same for the LABELLING_BACKEND (better name probably would have LLM in it). the idea here is to use a single interface to get at LLMs and put the sagemaker setup stuff in there - this way sagemaker is decoupled from batch and also it's more cohesive

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo