### PR TITLE
Add another method to the hosting environment

### DIFF
--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -16,6 +16,6 @@ class HostingEnvironment:
     def is_deployed() -> bool:
         environment = env.str("ENVIRONMENT", "").upper()
         deployed_envs = ["DEV", "DEVELOPMENT", "PREPROD", "PROD", "PRODUCTION"]
-        if environment in deployed_envs:
+        return environment in deployed_envs
             return True
         return False

--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -13,7 +13,7 @@ class HostingEnvironment:
         return env.str("ENVIRONMENT", "").upper() == "TEST"
 
     @staticmethod
-    def is_deployed() -> bool:  # How do we check if AWS?
+    def is_deployed() -> bool:
         environment = env.str("ENVIRONMENT", "").upper()
         deployed_envs = ["DEV", "DEVELOPMENT", "PREPROD", "PROD", "PRODUCTION"]
         if environment in deployed_envs:

--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -11,3 +11,11 @@ class HostingEnvironment:
     @staticmethod
     def is_test() -> bool:
         return env.str("ENVIRONMENT", "").upper() == "TEST"
+
+    @staticmethod
+    def is_deployed() -> bool:  # How do we check if AWS?
+        environment = env.str("ENVIRONMENT", "").upper()
+        deployed_envs = ["DEV", "DEVELOPMENT", "PREPROD", "PROD", "PRODUCTION"]
+        if environment in deployed_envs:
+            return True
+        return False

--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -17,5 +17,3 @@ class HostingEnvironment:
         environment = env.str("ENVIRONMENT", "").upper()
         deployed_envs = ["DEV", "DEVELOPMENT", "PREPROD", "PROD", "PRODUCTION"]
         return environment in deployed_envs
-            return True
-        return False


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Adding another function to check if the code has been deployed on dev/preprod/prod. In these cases the env vars should be set as "dev", "preprod" or "prod".

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A - to be used in other PRs, but trying to create some smaller commits.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - none to add, already added on dev/preprod/prod.