### PR TITLE
Bugfix/test get question responses page

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -25,9 +25,9 @@ class FakeConsultationData:
         q = self.questions[slug]
         return random.choice(q["answers"])
 
-    def get_multiple_choice_answer(self, slug):
-        q = self.questions[slug]
-        return random.choice(q["multiple_choice_options"])
+    # def get_multiple_choice_answer(self, slug):
+    #     q = self.questions[slug]
+    #     return random.choice(q["multiple_choice_options"])
 
     def all_questions(self):
         return list(self.questions.values())
@@ -135,11 +135,11 @@ class AnswerFactory(factory.django.DjangoModelFactory):
         model = models.Answer
         skip_postgeneration_save = True
 
-    multiple_choice_responses = factory.LazyAttribute(
-        lambda o: FakeConsultationData().get_multiple_choice_answer(o.question.slug)
-        if o.question.multiple_choice_options
-        else None
-    )
+    # multiple_choice_responses = factory.LazyAttribute(
+    #     lambda o: FakeConsultationData().get_multiple_choice_answer(o.question.slug)
+    #     if o.question.multiple_choice_options
+    #     else None
+    # )
 
     free_text = factory.LazyAttribute(
         lambda o: FakeConsultationData().get_free_text_answer(o.question.slug) if o.question.has_free_text else None
@@ -149,11 +149,18 @@ class AnswerFactory(factory.django.DjangoModelFactory):
     consultation_response = factory.SubFactory(ConsultationResponseFactory)
     theme = factory.SubFactory(ThemeFactory)
 
-    @factory.post_generation
-    def with_multiple_choice(answer, creation_strategy, value, **kwargs):
-        if answer.multiple_choice_responses is None:
-            answer.multiple_choice_responses = random.choice(default_multiple_choice_options)
-            answer.save()
+    # multiple_choice_responses = factory.LazyAttribute(lambda o: get_random_choice(factory.SelfAttribute("question.multiple_choice_options")))
+
+    multiple_choice_responses = factory.LazyAttribute(
+        lambda o: random.choice(o.question.multiple_choice_options) if o.question.multiple_choice_options else None
+    )
+
+    # Should this just relate to whether or not the question is multiple choice?
+    # @factory.post_generation
+    # def with_multiple_choice(answer, creation_strategy, value, **kwargs):
+    #     if answer.multiple_choice_responses is None:
+    #         answer.multiple_choice_responses = random.choice(default_multiple_choice_options)
+    #         answer.save()
 
     @factory.post_generation
     def with_free_text(answer, creation_strategy, value, **kwargs):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -25,10 +25,6 @@ class FakeConsultationData:
         q = self.questions[slug]
         return random.choice(q["answers"])
 
-    # def get_multiple_choice_answer(self, slug):
-    #     q = self.questions[slug]
-    #     return random.choice(q["multiple_choice_options"])
-
     def all_questions(self):
         return list(self.questions.values())
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -93,7 +93,8 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     @factory.post_generation
     def with_answer(question, creation_strategy, value, **kwargs):
         if value is True:
-            answer = AnswerFactory(question=question, with_multiple_choice=kwargs.get("with_multiple_choice"))
+            # answer = AnswerFactory(question=question, with_multiple_choice=kwargs.get("with_multiple_choice"))
+            answer = AnswerFactory(question=question)
             answer.save()
 
     @factory.post_generation
@@ -107,7 +108,7 @@ class QuestionFactory(factory.django.DjangoModelFactory):
         if value is True:
             answer = AnswerFactory(
                 question=question,
-                with_multiple_choice=kwargs.get("with_multiple_choice"),
+                # with_multiple_choice=kwargs.get("with_multiple_choice"),
                 with_free_text=kwargs.get("with_free_text"),
             )
             answer.save()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -93,7 +93,6 @@ class QuestionFactory(factory.django.DjangoModelFactory):
     @factory.post_generation
     def with_answer(question, creation_strategy, value, **kwargs):
         if value is True:
-            # answer = AnswerFactory(question=question, with_multiple_choice=kwargs.get("with_multiple_choice"))
             answer = AnswerFactory(question=question)
             answer.save()
 
@@ -108,7 +107,6 @@ class QuestionFactory(factory.django.DjangoModelFactory):
         if value is True:
             answer = AnswerFactory(
                 question=question,
-                # with_multiple_choice=kwargs.get("with_multiple_choice"),
                 with_free_text=kwargs.get("with_free_text"),
             )
             answer.save()
@@ -136,12 +134,6 @@ class AnswerFactory(factory.django.DjangoModelFactory):
         model = models.Answer
         skip_postgeneration_save = True
 
-    # multiple_choice_responses = factory.LazyAttribute(
-    #     lambda o: FakeConsultationData().get_multiple_choice_answer(o.question.slug)
-    #     if o.question.multiple_choice_options
-    #     else None
-    # )
-
     free_text = factory.LazyAttribute(
         lambda o: FakeConsultationData().get_free_text_answer(o.question.slug) if o.question.has_free_text else None
     )
@@ -150,18 +142,9 @@ class AnswerFactory(factory.django.DjangoModelFactory):
     consultation_response = factory.SubFactory(ConsultationResponseFactory)
     theme = factory.SubFactory(ThemeFactory)
 
-    # multiple_choice_responses = factory.LazyAttribute(lambda o: get_random_choice(factory.SelfAttribute("question.multiple_choice_options")))
-
     multiple_choice_responses = factory.LazyAttribute(
         lambda o: random.choice(o.question.multiple_choice_options) if o.question.multiple_choice_options else None
     )
-
-    # Should this just relate to whether or not the question is multiple choice?
-    # @factory.post_generation
-    # def with_multiple_choice(answer, creation_strategy, value, **kwargs):
-    #     if answer.multiple_choice_responses is None:
-    #         answer.multiple_choice_responses = random.choice(default_multiple_choice_options)
-    #         answer.save()
 
     @factory.post_generation
     def with_free_text(answer, creation_strategy, value, **kwargs):


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Fixing the error which occurs occasionally when running tests - when we're trying to generate an "Answer" factory.

The error only happens occasionally as we are choosing random options from a file each time e.g. https://github.com/i-dot-ai/consultation-analyser/actions/runs/8561487377/job/23462787062?pr=64

I think error arises because we're trying to generate a multiple choice answer for the `Answer` model, when the `Question` it relates to doesn't have multiple choice options. (Hard to replicate due to randomness.)

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
When generating the `AnswerFactory` generate the multiple choice response based on the options in the related question (don't read from the YAML file options, as sometimes the multiple choices are generated separately).

Also fix the issue where an `Answer` was given a multiple choice response when the possible options on the question were empty.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check nothing is broken? Do tests pass? 

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A - quick bug fix.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo