### PR TITLE
Add file upload journey to frontend prototype

### DIFF
--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -82,22 +82,37 @@ $iai-colour-pink: #b62777;
 .iai-filters {
     background-color: govuk-colour("light-grey");
     padding: 1rem;
-  }
-  @media (min-width: 641px) {
+}
+@media (min-width: 641px) {
     .iai-filters {
       max-width: 14rem;
     }
-  }
-  .iai-filters .govuk-form-group {
+}
+.iai-filters .govuk-form-group {
     /*margin-bottom: 1.5rem;*/
-  }
+}
 
-  .iai-table-subhead {
+.iai-table-subhead {
     display: block;
     font-size: 1.125rem;
     font-weight: 100;
-  }
+}
 pre code {
   white-space: pre-wrap;
   font-size: 80%;
+}
+
+
+/** UPLOAD PAGE **/
+.iai-error-list {
+    list-style-type: disc;
+    color: govuk-colour("red");
+    font-weight: 700;
+    padding-left: 1.25rem;
+  }
+.iai-label__additional-text {
+    color: govuk-colour("dark-grey");
+    display: block;
+    font-size: 1rem;
+    margin: 0.25rem 0;
 }

--- a/prototype/app/assets/sass/application.scss
+++ b/prototype/app/assets/sass/application.scss
@@ -3,16 +3,13 @@
 // https://prototype-kit.service.gov.uk/docs/adding-css-javascript-and-images
 //
 
-:root {
-  --iai-pink: #b62777;
-  --govuk-light-blue: #5694ca;
-}
+$iai-colour-pink: #b62777;
 
 .govuk-header__container {
-  border-color: var(--iai-pink);
+  border-color: $iai-colour-pink;
 }
 .govuk-phase-banner__content__tag {
-  background-color: var(--iai-pink);
+  background-color: $iai-colour-pink;
   color: white;
 }
 
@@ -57,7 +54,7 @@
   z-index: 10;
 }
 .iai-bar__bar {
-  background-color: var(--govuk-light-blue);
+  background-color: govuk-colour("light-blue");
   display: block;
   height: 100%;
   left: 0;
@@ -97,4 +94,19 @@
   display: block;
   font-size: 1.125rem;
   font-weight: 100;
+}
+
+
+/** UPLOAD PAGE **/
+.iai-error-list {
+  list-style-type: disc;
+  color: govuk-colour("red");
+  font-weight: 700;
+  padding-left: 1.25rem;
+}
+.iai-label__additional-text {
+  color: govuk-colour("dark-grey");
+  display: block;
+  font-size: 1rem;
+  margin: 0.25rem 0;
 }

--- a/prototype/app/routes.js
+++ b/prototype/app/routes.js
@@ -6,4 +6,16 @@
 const govukPrototypeKit = require('govuk-prototype-kit')
 const router = govukPrototypeKit.requests.setupRouter()
 
-// Add your routes here
+router.post('/upload-file', (request, response) => {
+    const isJsonFile = request.session.data.file?.includes('.js');
+    if (isJsonFile) {
+        request.session.data.schemaErrors = [];
+        response.redirect('/upload-success');
+    } else {
+        request.session.data.schemaErrors = [
+            'Line 10: Invalid property',
+            'Line 20: Missing property "Answer"'
+        ];
+        response.redirect('/upload');
+    }
+});

--- a/prototype/app/views/demo-consultation.html
+++ b/prototype/app/views/demo-consultation.html
@@ -1,0 +1,245 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+
+{% block pageTitle %}Consultation on Fourth Sector Pathfinders{% endblock %}
+
+{% block content %}
+
+<script src="https://cdn.anychart.com/releases/8.0.0/js/anychart-base.min.js"></script>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-m">Department of Social Affairs and Citizenship</span>
+    <h1 class="govuk-heading-l">Consultation on Fourth Sector Pathfinders</h1>
+
+    {% set tab1 %}
+      <h2 class="govuk-heading-m">Responses processed</h2>
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Total"
+            },
+            value: {
+              text: "27,921"
+            }
+          },
+          {
+            key: {
+              text: "England"
+            },
+            value: {
+              text: "21,701"
+            }
+          },
+          {
+            key: {
+              text: "Scotland"
+            },
+            value: {
+              text: "3,089"
+            }
+          },
+          {
+            key: {
+              text: "Wales"
+            },
+            value: {
+              text: "1,018"
+            }
+          },
+          {
+            key: {
+              text: "Northern Ireland"
+            },
+            value: {
+              text: "1,221"
+            }
+          }
+        ]
+      }) }}
+    {% endset %}
+
+    {% set tab2 %}
+      <h2 class="govuk-heading-m">Key findings</h2>
+
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Fourth sector pathfinders:</h3>
+      <div class="iai-key-finding">
+        <div class="iai-key-finding__chart">
+          <canvas data-yes="63" data-no="33"></canvas>
+        </div>
+        <div>
+          <p class="govuk-!-margin-bottom-1"><strong>63% of respondents are in favour of the fourth sector pathfinder policy, 33% are opposed</strong></p>
+          <p class="govuk-!-margin-bottom-0">The key argument expressed in the responses is that pathfinding is a major issue in the fourth sector and that strict measures need to be implemented to ensure its continuation.</p>
+        </div>
+      </div>
+
+      <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Product scope:</h3>
+      <div class="iai-key-finding">
+        <div class="iai-key-finding__chart">
+          <canvas data-yes="63" data-no="31"></canvas>
+        </div>
+        <div>
+          <p class="govuk-!-margin-bottom-1"><strong>63% of respondents agree that all pathfinding projects be coverd by the new legislation</strong></p>
+          <p class="govuk-!-margin-bottom-0">Respondents express support in order to find paths harmoniously and protect the finders of paths. Respondents also commonly agree that all pathfinding products should be covered to promote complete pathfinding satisfaction and prevent loopholes that stray from paths thus discovered.</p>
+        </div>
+      </div>
+
+      <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Part time pathfinders:</h3>
+      <div class="iai-key-finding">
+        <div class="iai-key-finding__chart">
+          <canvas data-yes="79" data-no="18"></canvas>
+        </div>
+        <div>
+          <p class="govuk-!-margin-bottom-1"><strong>79% of respondents agree that there should be restrictions on part time pathfinders, 18% are opposed</strong></p>
+          <p class="govuk-!-margin-bottom-0">Respondents cite negative impacts on paths found and on the fourth sector as a whole as the key reasons for support.</p>
+        </div>
+      </div>
+
+      <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Enforcement:</h3>
+      <div class="iai-key-finding">
+        <div class="iai-key-finding__chart">
+          <canvas data-yes="88" data-no="9"></canvas>
+        </div>
+        <div>
+          <p class="govuk-!-margin-bottom-1"><strong>88% of respondents think that that fixed penalty notices should be issued for paths that turn out not to lead anywhere, 9% are opposed</strong></p>
+          <p class="govuk-!-margin-bottom-0">Respondents commonly believe that FPNs would help restrict the provision of these paths to consenting bodies and make suppliers comply with the law.</p>
+        </div>
+      </div>
+
+    {% endset %}
+
+    {% set tab3 %}
+      <h2 class="govuk-heading-m">Contacts</h2>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">DOSaC:</h3>
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Policy"
+            },
+            value: {
+              text: "firstname.lastname@dosac.gov.uk"
+            }
+          },
+          {
+            key: {
+              text: "Analyst"
+            },
+            value: {
+              text: "firstname.lastname@dosac.gov.uk"
+            }
+          },
+          {
+            key: {
+              text: "Data Science"
+            },
+            value: {
+              text: "firstname.lastname@dosac.gov.uk"
+            }
+          }
+        ]
+      }) }}
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">10DS:</h3>
+      {{ govukSummaryList({
+        rows: [
+          {
+            key: {
+              text: "Analyst"
+            },
+            value: {
+              text: "firstname.lastname@no10.gov.uk"
+            }
+          },
+          {
+            key: {
+              text: "Social Affairs Lead"
+            },
+            value: {
+              text: "firstname.lastname@no10.gov.uk"
+            }
+          }
+        ]
+      }) }}
+    {% endset %}
+
+    {{ govukTabs({
+      items: [
+        {
+          label: "Responses processed",
+          id: "responses",
+          panel: {
+            html: tab1
+          }
+        },
+        {
+          label: "Key findings",
+          id: "findings",
+          panel: {
+            html: tab2
+          }
+        },
+        {
+          label: "Contacts",
+          id: "contacts",
+          panel: {
+            html: tab3
+          }
+        }
+      ]
+    }) }}
+
+
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Questions</h2>
+    <ul class="iai-questions govuk-!-padding-0">
+      {% for question in data.questions %}
+        <li class="iai-questions__item govuk-!-margin-top-3">
+          <p class="govuk-!-margin-bottom-1">{{question}}</p>
+          <span class="iai-questions__links govuk-!-margin-top-2">
+            <a href="/question-summary?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all" class="govuk-link govuk-link--no-visited-state">Question summary</a>
+            <a href="/question-responses?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all" class="govuk-link govuk-link--no-visited-state">Explore responses</a>
+          </span>
+        </li>
+      {% endfor %}
+    </ul>
+
+    {#
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-top-4">
+        <h2 class="govuk-heading-m">Questions</h2>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Question</th>
+          <th scope="col" class="govuk-table__header" style="width: 22.25rem;">Actions</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for question in data.questions %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">{{question}}</td>
+            <td class="govuk-table__cell">
+              {{ govukButton({
+                text: "Question summary",
+                classes: "govuk-button--secondary",
+                href: "/question-summary?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all"
+              }) }}
+              {{ govukButton({
+                text: "Explore responses",
+                classes: "govuk-button--secondary",
+                href: "/question-responses?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all"
+              }) }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    #}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/prototype/app/views/index.html
+++ b/prototype/app/views/index.html
@@ -2,244 +2,32 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% set pageName="Home" %}
 
-{% block pageTitle %}Consultation on Fourth Sector Pathfinders{% endblock %}
+{% block pageTitle %}Home{% endblock %}
 
 {% block content %}
 
-<script src="https://cdn.anychart.com/releases/8.0.0/js/anychart-base.min.js"></script>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-m">Department of Social Affairs and Citizenship</span>
-    <h1 class="govuk-heading-l">Consultation on Fourth Sector Pathfinders</h1>
+    <h1 class="govuk-heading-l">Consultations frontend prototype</h1>
 
-    {% set tab1 %}
-      <h2 class="govuk-heading-m">Responses processed</h2>
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: {
-              text: "Total"
-            },
-            value: {
-              text: "27,921"
-            }
-          },
-          {
-            key: {
-              text: "England"
-            },
-            value: {
-              text: "21,701"
-            }
-          },
-          {
-            key: {
-              text: "Scotland"
-            },
-            value: {
-              text: "3,089"
-            }
-          },
-          {
-            key: {
-              text: "Wales"
-            },
-            value: {
-              text: "1,018"
-            }
-          },
-          {
-            key: {
-              text: "Northern Ireland"
-            },
-            value: {
-              text: "1,221"
-            }
-          }
-        ]
-      }) }}
-    {% endset %}
-
-    {% set tab2 %}
-      <h2 class="govuk-heading-m">Key findings</h2>
-
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Fourth sector pathfinders:</h3>
-      <div class="iai-key-finding">
-        <div class="iai-key-finding__chart">
-          <canvas data-yes="63" data-no="33"></canvas>
-        </div>
-        <div>
-          <p class="govuk-!-margin-bottom-1"><strong>63% of respondents are in favour of the fourth sector pathfinder policy, 33% are opposed</strong></p>
-          <p class="govuk-!-margin-bottom-0">The key argument expressed in the responses is that pathfinding is a major issue in the fourth sector and that strict measures need to be implemented to ensure its continuation.</p>
-        </div>
-      </div>
-
-      <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Product scope:</h3>
-      <div class="iai-key-finding">
-        <div class="iai-key-finding__chart">
-          <canvas data-yes="63" data-no="31"></canvas>
-        </div>
-        <div>
-          <p class="govuk-!-margin-bottom-1"><strong>63% of respondents agree that all pathfinding projects be coverd by the new legislation</strong></p>
-          <p class="govuk-!-margin-bottom-0">Respondents express support in order to find paths harmoniously and protect the finders of paths. Respondents also commonly agree that all pathfinding products should be covered to promote complete pathfinding satisfaction and prevent loopholes that stray from paths thus discovered.</p>
-        </div>
-      </div>
-
-      <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Part time pathfinders:</h3>
-      <div class="iai-key-finding">
-        <div class="iai-key-finding__chart">
-          <canvas data-yes="79" data-no="18"></canvas>
-        </div>
-        <div>
-          <p class="govuk-!-margin-bottom-1"><strong>79% of respondents agree that there should be restrictions on part time pathfinders, 18% are opposed</strong></p>
-          <p class="govuk-!-margin-bottom-0">Respondents cite negative impacts on paths found and on the fourth sector as a whole as the key reasons for support.</p>
-        </div>
-      </div>
-
-      <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Enforcement:</h3>
-      <div class="iai-key-finding">
-        <div class="iai-key-finding__chart">
-          <canvas data-yes="88" data-no="9"></canvas>
-        </div>
-        <div>
-          <p class="govuk-!-margin-bottom-1"><strong>88% of respondents think that that fixed penalty notices should be issued for paths that turn out not to lead anywhere, 9% are opposed</strong></p>
-          <p class="govuk-!-margin-bottom-0">Respondents commonly believe that FPNs would help restrict the provision of these paths to consenting bodies and make suppliers comply with the law.</p>
-        </div>
-      </div>
-
-    {% endset %}
-
-    {% set tab3 %}
-      <h2 class="govuk-heading-m">Contacts</h2>
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">DOSaC:</h3>
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: {
-              text: "Policy"
-            },
-            value: {
-              text: "firstname.lastname@dosac.gov.uk"
-            }
-          },
-          {
-            key: {
-              text: "Analyst"
-            },
-            value: {
-              text: "firstname.lastname@dosac.gov.uk"
-            }
-          },
-          {
-            key: {
-              text: "Data Science"
-            },
-            value: {
-              text: "firstname.lastname@dosac.gov.uk"
-            }
-          }
-        ]
-      }) }}
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">10DS:</h3>
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: {
-              text: "Analyst"
-            },
-            value: {
-              text: "firstname.lastname@no10.gov.uk"
-            }
-          },
-          {
-            key: {
-              text: "Social Affairs Lead"
-            },
-            value: {
-              text: "firstname.lastname@no10.gov.uk"
-            }
-          }
-        ]
-      }) }}
-    {% endset %}
-
-    {{ govukTabs({
-      items: [
-        {
-          label: "Responses processed",
-          id: "responses",
-          panel: {
-            html: tab1
-          }
-        },
-        {
-          label: "Key findings",
-          id: "findings",
-          panel: {
-            html: tab2
-          }
-        },
-        {
-          label: "Contacts",
-          id: "contacts",
-          panel: {
-            html: tab3
-          }
-        }
-      ]
+    <h2 class="govuk-heading-m">Demo consultation</h2>
+    <p>The demo consultation shows how each page will look and what features will be available.</p>
+    {{ govukButton({
+      text: "View consultation",
+      href: "/demo-consultation",
+      isStartButton: true
     }) }}
 
-
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Questions</h2>
-    <ul class="iai-questions govuk-!-padding-0">
-      {% for question in data.questions %}
-        <li class="iai-questions__item govuk-!-margin-top-3">
-          <p class="govuk-!-margin-bottom-1">{{question}}</p>
-          <span class="iai-questions__links govuk-!-margin-top-2">
-            <a href="/question-summary?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all" class="govuk-link govuk-link--no-visited-state">Question summary</a>
-            <a href="/question-responses?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all" class="govuk-link govuk-link--no-visited-state">Explore responses</a>
-          </span>
-        </li>
-      {% endfor %}
-    </ul>
-
-    {#
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m govuk-!-margin-top-4">
-        <h2 class="govuk-heading-m">Questions</h2>
-      </caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Question</th>
-          <th scope="col" class="govuk-table__header" style="width: 22.25rem;">Actions</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        {% for question in data.questions %}
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{question}}</td>
-            <td class="govuk-table__cell">
-              {{ govukButton({
-                text: "Question summary",
-                classes: "govuk-button--secondary",
-                href: "/question-summary?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all"
-              }) }}
-              {{ govukButton({
-                text: "Explore responses",
-                classes: "govuk-button--secondary",
-                href: "/question-responses?question-index={{loop.index0}}&keyword=&theme=all&opinion=all&location=all&age=all&capacity=all"
-              }) }}
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-    #}
+    <h2 class="govuk-heading-m govuk-!-margin-top-3">Upload consultation</h2>
+    <p>This is an MVP version just for use by the i.AI team currently. Longer term this can be expanded to be useable by others. At which point we'll need to consider what additional data/instructions will be required.</p>
+    {{ govukButton({
+      text: "Upload consultation",
+      classes: "govuk-button--secondary",
+      href: "/upload"
+    }) }}
 
   </div>
 </div>

--- a/prototype/app/views/question-responses.html
+++ b/prototype/app/views/question-responses.html
@@ -6,14 +6,12 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageName="Home" %}
-
 {% block pageTitle %}Responses to question {{data["question-index"]|int + 1}}{% endblock %}
 
 {% block beforeMain %}
   {{ govukBackLink({
     text: "Back to all questions",
-    href: "/"
+    href: "/demo-consultation"
   }) }}
 {% endblock %}
 

--- a/prototype/app/views/question-summary.html
+++ b/prototype/app/views/question-summary.html
@@ -6,14 +6,12 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageName="Home" %}
-
 {% block pageTitle %}Question Summary for question {{data["question-index"]|int + 1}}{% endblock %}
 
 {% block beforeMain %}
   {{ govukBackLink({
     text: "Back to all questions",
-    href: "/"
+    href: "/demo-consultation"
   }) }}
 {% endblock %}
 

--- a/prototype/app/views/respondent.html
+++ b/prototype/app/views/respondent.html
@@ -4,8 +4,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageName="Home" %}
-
 {% block pageTitle %}Respondent A{% endblock %}
 
 {% block beforeMain %}

--- a/prototype/app/views/upload-success.html
+++ b/prototype/app/views/upload-success.html
@@ -1,0 +1,24 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% block pageTitle %}Upload confirmation{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    {{ govukPanel({
+      titleText: "File uploaded",
+      html: "The consultation is now being processed"
+    }) }}
+
+    <p class="govuk-!-margin-top-5">The consultation will take some time to process. Once it is ready it will be available to view at <a href="/demo-consultation">/demo-consultation</a>.</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/prototype/app/views/upload.html
+++ b/prototype/app/views/upload.html
@@ -1,0 +1,80 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% block pageTitle %}Upload consultation{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {% if data.schemaErrors %}
+      <div class="govuk-error-summary" data-module="govuk-error-summary">
+        <div role="alert">
+          <h2 class="govuk-error-summary__title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list iai-error-list">
+              {% for error in data.schemaErrors %}
+                <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    <h1 class="govuk-heading-l">Upload a consultation</h1>
+
+    <form action="/upload-file" method="post">
+
+      {# If/when we allow users to upload their own files, we may require this #}
+      {#
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="name">
+          Your name
+        </label>
+        <input class="govuk-input" id="name" name="name" type="text" autocomplete="name" spellcheck="false" required value="{{ data.name }}">
+      </div>
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="email">
+          Your email address
+        </label>
+        <input class="govuk-input" id="email" name="email" type="email" autocomplete="email" spellcheck="false" required value="{{ data.email }}">
+      </div>
+      #}
+
+      {% if data.schemaErrors %}
+        <div class="govuk-form-group govuk-form-group--error">
+          <label class="govuk-label" for="file">
+            Upload a file
+            <span class="iai-label__additional-text">Files must be in JSON format, to match the <a href="#schema">required schema</a></span>
+          </label>
+          <p id="file-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> The file has the incorrect schema
+          </p>
+          <input class="govuk-file-upload govuk-file-upload--error" id="file" name="file" type="file" aria-describedby="file-error" required>
+        </div>
+      {% else %}
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="file">
+            Upload a file
+            <span class="iai-label__additional-text">Files must be in JSON format, to match the <a href="#schema">required schema</a></span>
+          </label>
+          <input class="govuk-file-upload" id="file" name="file" type="file" required>
+        </div>
+      {% endif %}
+
+      {{ govukButton({
+        text: "Continue"
+      }) }}
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
## Context

This work is to prototype the file upload journey when uploading the initial consultation JSON.


## Changes proposed in this pull request

* ### Updating the prototype homepage to easily locate this journey:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/203e769e-6396-42dc-b775-36596bbfb41f)

* ### The actual file upload page:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/a1d36dc1-d5e2-480c-9422-859344ca8a3c)

* ### Validation errors if there is a problem with the file or upload process:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/3038d86c-2941-414d-9c14-11b11788233e)

* ### Confirmation page if upload and validation successful:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/259462b6-a2b5-4fab-b4f8-b94f266ac07a)


## Guidance to review / things to check

* Start the frontend prototype and follow the journey starting at `https://localhost:3000`.
* If you try uploading anything other than a `.json` or `.js` file, the validation error messages should display (this is just a quick way of simulating the validation process which will obviously be more detailed in the actual app).
* Continuing with uploading a suitable file takes you to the confirmation page.


## Thoughts / questions

* I don't *think* we need to collect any more data during the process, as everything else will be contained within the JSON file. Is this assumption correct? Is there anything I haven't allowed for?
* If the form is longer we should follow the [one question per page](https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page) rule. We *could* also do that here but I'm not certain it would be helpful in this instance.