### PR TITLE
Fix tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-DJANGO_SETTINGS_MODULE=consultation_analyser.settings.local
 ENVIRONMENT=local
 DEBUG=True
 DJANGO_SECRET_KEY=dummy-key

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 export
 
 .PHONY: help
-help: ## Show this help
-	@grep -E '^[a-zA-Z\.\-\_]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+help:     ## Show this help.
+	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
 
 ## Schema documentation
 consultation_analyser/consultations/public_schema.py: consultation_analyser/consultations/public_schema/public_schema.yaml

--- a/consultation_analyser/settings/test.py
+++ b/consultation_analyser/settings/test.py
@@ -6,6 +6,6 @@ import environ
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Take environment variables from .env file
-environ.Env.read_env(os.path.join(BASE_DIR, ".env.test"))
+environ.Env.read_env(os.path.join(BASE_DIR, ".env.test"), overwrite=True)
 
 from consultation_analyser.settings.base import *  # noqa


### PR DESCRIPTION
## Context

Tests were broken after the Makefile introduced a line to read from `.env`

## Changes proposed in this pull request

- cause `settings/test.py` to explicitly override what's already in `.env`
- remove `DJANGO_SETTINGS_MODULE` from `.env.example` (this isn't required as it's hardcoded in `manage.py`)
- fix the `make help` command

## Guidance to review

Does `make test` work?

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo