### PR TITLE
Change name to "Consultation analyser"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Consultation Analyser
+# Consultation analyser
 
 The Consultation analyser is a machine learning and LLM-powered tool to automate the processing of public consultations.
 

--- a/consultation_analyser/consultations/jinja2/base.html
+++ b/consultation_analyser/consultations/jinja2/base.html
@@ -7,7 +7,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>{% if page_title %}{{ page_title }} - {% endif %}Consultation Analyser</title>
+  <title>{% if page_title %}{{ page_title }} - {% endif %}Consultation analyser</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 
@@ -31,7 +31,7 @@
 
   {{ govukHeader({
     "homepageUrl": "https://www.gov.uk",
-    "serviceName": "Consultations Analyser",
+    "serviceName": "Consultation analyser",
     "serviceUrl": "/",
     'navigation': [
       {

--- a/consultation_analyser/consultations/jinja2/privacy.html
+++ b/consultation_analyser/consultations/jinja2/privacy.html
@@ -4,7 +4,7 @@
 {%- set page_title = "Privacy" -%}
 
 {% block content %}
-  <h1 class="govuk-heading-l">Privacy notice for Consultations Analyser</h1>
+  <h1 class="govuk-heading-l">Privacy notice for Consultation analyser</h1>
   <div class="govuk-body">
     <p class="govuk-body-l">This notice sets out how we will use your personal data, and your rights. It is made under Articles 13 and/or 14 of the UK General Data Protection Regulation (UK GDPR).</p>
 

--- a/prototype/app/views/layouts/main.html
+++ b/prototype/app/views/layouts/main.html
@@ -7,7 +7,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{% block pageTitle %}{% endblock %} – Consultations Analyser - GOV.UK Prototype Kit</title>
+    <title>{% block pageTitle %}{% endblock %} – Consultation analyser - GOV.UK Prototype Kit</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">


### PR DESCRIPTION
## Context

As discussed in standup, this is to change the name to "Consultation analyser": "Consultation" singular, "analyser" lowercase "a".

## Things to check

That the name has been changed everywhere:
* On pages
* The page `<title>`s
* Prototype kit
* Readme
* Anywhere else? (I've done a text search on the repo, so hopefully not!)