### PR TITLE
Move factories to .consultation_analyser

### DIFF
--- a/consultation_analyser/consultations/dummy_data.py
+++ b/consultation_analyser/consultations/dummy_data.py
@@ -1,7 +1,6 @@
 import random
 
-from consultation_analyser.hosting_environment import HostingEnvironment
-from tests.factories import (
+from consultation_analyser.factories import (
     AnswerFactory,
     ConsultationFactory,
     ConsultationResponseFactory,
@@ -10,6 +9,7 @@ from tests.factories import (
     SectionFactory,
     ThemeFactory,
 )
+from consultation_analyser.hosting_environment import HostingEnvironment
 
 
 class DummyConsultation:

--- a/consultation_analyser/factories.py
+++ b/consultation_analyser/factories.py
@@ -65,10 +65,12 @@ class SectionFactory(factory.django.DjangoModelFactory):
 
     name = faker.sentence()
     slug = faker.slug()
-    consultation = factory.SubFactory("tests.factories.ConsultationFactory")
+    consultation = factory.SubFactory("consultation_analyser.factories.ConsultationFactory")
 
     class Params:
-        with_questions = factory.Trait(questions=[factory.SubFactory("tests.factories.QuestionFactory")])
+        with_questions = factory.Trait(
+            questions=[factory.SubFactory("consultation_analyser.factories.QuestionFactory")]
+        )
 
     @factory.post_generation
     def with_question(section, creation_strategy, value, **kwargs):

--- a/tests/integration/test_consultation_page.py
+++ b/tests/integration/test_consultation_page.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.factories import ConsultationFactory
+from consultation_analyser.factories import ConsultationFactory
 
 
 @pytest.mark.django_db

--- a/tests/integration/test_home_page.py
+++ b/tests/integration/test_home_page.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.factories import ConsultationFactory
+from consultation_analyser.factories import ConsultationFactory
 
 
 @pytest.mark.django_db

--- a/tests/integration/test_ml_pipeline.py
+++ b/tests/integration/test_ml_pipeline.py
@@ -1,10 +1,10 @@
 import pytest
 
+from consultation_analyser import factories
 from consultation_analyser.consultations import models
 from consultation_analyser.consultations.ml_pipeline import (
     save_themes_for_consultation,
 )
-from tests import factories
 
 
 @pytest.mark.django_db

--- a/tests/integration/test_question_pages.py
+++ b/tests/integration/test_question_pages.py
@@ -3,7 +3,7 @@ import re
 
 import pytest
 
-from tests.factories import AnswerFactory, ConsultationFactory
+from consultation_analyser.factories import AnswerFactory, ConsultationFactory
 
 
 @pytest.mark.django_db

--- a/tests/integration/test_responses_pages.py
+++ b/tests/integration/test_responses_pages.py
@@ -2,7 +2,7 @@ import html
 
 import pytest
 
-from tests.factories import ConsultationFactory
+from consultation_analyser.factories import ConsultationFactory
 
 
 @pytest.mark.django_db

--- a/tests/unit/test_ml_pipeline_functions.py
+++ b/tests/unit/test_ml_pipeline_functions.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from consultation_analyser import factories
 from consultation_analyser.consultations import ml_pipeline, models
-from tests import factories
 
 
 def test_get_embeddings_for_question():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 
+from consultation_analyser import factories
 from consultation_analyser.consultations import models
-from tests import factories
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Context

@nmenezes0 found during #64 that python couldn't resolve `tests.factories` when running under `gunicorn`. We couldn't figure out a way to make it resolve, so we're moving `factories` under `consultation_analyser`

## Changes proposed in this pull request

Move `factories` under `consultation_analyser`

## Guidance to review

Tests should still pass!

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo