### PR TITLE
Build new homepage and menu structure in prototype

### DIFF
--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -1,7 +1,7 @@
 $govuk-assets-path: "govuk-assets/";
 $govuk-font-family: sans-serif;
 
-$iai-colour-pink: #b62777;
+$iai-colour-pink: #C50878;
 
 @import "node_modules/govuk-frontend/dist/govuk/all";
 

--- a/prototype/app/assets/sass/application.scss
+++ b/prototype/app/assets/sass/application.scss
@@ -3,7 +3,10 @@
 // https://prototype-kit.service.gov.uk/docs/adding-css-javascript-and-images
 //
 
-$iai-colour-pink: #b62777;
+@import "node_modules/@x-govuk/govuk-prototype-components/x-govuk/all";
+
+$govuk-brand-colour: #C50878;
+$iai-colour-pink: #C50978;
 
 .govuk-header__container {
   border-color: $iai-colour-pink;
@@ -12,6 +15,46 @@ $iai-colour-pink: #b62777;
   background-color: $iai-colour-pink;
   color: white;
 }
+
+/* HOMEPAGE */
+.x-govuk-masthead--pink {
+  background-color: $iai-colour-pink;
+}
+.x-govuk-masthead--pink .govuk-phase-banner {
+  border-bottom-color: white;
+}
+.x-govuk-masthead--pink .govuk-tag {
+  background-color: white;
+  color: $iai-colour-pink;
+}
+.x-govuk-masthead--pink .govuk-button {
+  box-shadow: 0 2px 0 govuk-colour("dark-grey");
+  color: $iai-colour-pink;
+}
+.x-govuk-primary-navigation__link {
+  color: govuk-colour("dark-grey") !important;
+}
+.x-govuk-primary-navigation__item--current {
+  border-bottom-color: govuk-colour("dark-grey");
+}
+
+.iai-processlist {
+  padding: 0;
+}
+.iai-processlist__item {
+  display: flex;
+  align-items: center;
+  list-style-type: none;
+  margin: 3rem 0;
+}
+.iai-processlist__item svg {
+  color: $iai-colour-pink;
+  width: 5rem;
+}
+.iai-processlist__text {
+  margin-left: 1.5rem;
+}
+
 
 /** START PAGE **/
 .iai-key-finding {

--- a/prototype/app/config.json
+++ b/prototype/app/config.json
@@ -1,3 +1,3 @@
 {
-  "serviceName": "Consultations Tool"
+  "serviceName": "Consultation analyser"
 }

--- a/prototype/app/views/data-format.html
+++ b/prototype/app/views/data-format.html
@@ -1,0 +1,16 @@
+{% extends "layouts/main.html" %}
+
+{% set pageTitle = "Data schema" %}
+
+{% block content %}
+
+<div class="govuk-width-container ">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Data schema</h1>
+      <p>(The data schema is generated in main site. Not displayed here to avoid displaying an outdated version.)</p>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/prototype/app/views/demo-consultation.html
+++ b/prototype/app/views/demo-consultation.html
@@ -1,4 +1,4 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}

--- a/prototype/app/views/index.html
+++ b/prototype/app/views/index.html
@@ -3,33 +3,101 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageName="Home" %}
-
-{% block pageTitle %}Home{% endblock %}
+{% set pageTitle = "" %}
 
 {% block content %}
+<style>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Consultations frontend prototype</h1>
-
-    <h2 class="govuk-heading-m">Demo consultation</h2>
-    <p>The demo consultation shows how each page will look and what features will be available.</p>
-    {{ govukButton({
-      text: "View consultation",
-      href: "/demo-consultation",
-      isStartButton: true
-    }) }}
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-3">Upload consultation</h2>
-    <p>This is an MVP version just for use by the i.AI team currently. Longer term this can be expanded to be useable by others. At which point we'll need to consider what additional data/instructions will be required.</p>
-    {{ govukButton({
-      text: "Upload consultation",
-      classes: "govuk-button--secondary",
-      href: "/upload"
-    }) }}
-
+  .govuk-main-wrapper {
+    padding-top: 0;
+  }
+  .govuk-phase-banner {
+    border-bottom: 0;
+  }
+  .govuk-phase-banner__text .govuk-link {
+    /*color: white;*/
+  }
+</style>
+<div class="x-govuk-masthead x-govuk-masthead--pink">
+  <div class="govuk-width-container">
+    {#
+    <div class="govuk-phase-banner x-govuk-phase-banner--inverse">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag x-govuk-tag--inverse">
+          Prototype
+        </strong>
+        <span class="govuk-phase-banner__text">
+          This is a new service – your <a class="govuk-link" href="#feedback">feedback</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
+    #}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="x-govuk-masthead__title">
+          Use machine learning to help you understand consultation responses
+        </h1>
+        <p class="x-govuk-masthead__description">
+          Work with i.AI to use the prototype Consultation analyser to see how it could work for your consultation.
+        </p>
+        <a href="/get-involved" role="button" draggable="false" class="govuk-button govuk-button--inverse govuk-button--start" data-module="govuk-button">
+          Get involved
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+          </svg>
+        </a>
+      </div>
+    </div>
   </div>
 </div>
+
+{# icons from https://iconoir.com/ #}
+{% set processList = [
+  {
+    title: "Agree to share your data",
+    text: 'Before you can use our tool you need to agree to <a href="/data-sharing">data sharing</a>.',
+    icon: '<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor" aria-hidden="true"><path d="M18 22C19.6569 22 21 20.6569 21 19C21 17.3431 19.6569 16 18 16C16.3431 16 15 17.3431 15 19C15 20.6569 16.3431 22 18 22Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M18 8C19.6569 8 21 6.65685 21 5C21 3.34315 19.6569 2 18 2C16.3431 2 15 3.34315 15 5C15 6.65685 16.3431 8 18 8Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M6 15C7.65685 15 9 13.6569 9 12C9 10.3431 7.65685 9 6 9C4.34315 9 3 10.3431 3 12C3 13.6569 4.34315 15 6 15Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M15.5 6.5L8.5 10.5" stroke="currentColor" stroke-width="1.5"></path><path d="M8.5 13.5L15.5 17.5" stroke="currentColor" stroke-width="1.5"></path></svg>'
+  },
+  {
+    title: "Upload your data",
+    text: "You will be given a log in to securely upload your data to the tool.",
+    icon: '<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor" aria-hidden="true"><path d="M20 13V19C20 20.1046 19.1046 21 18 21H6C4.89543 21 4 20.1046 4 19V13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M12 15V3M12 3L8.5 6.5M12 3L15.5 6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+  },
+  {
+    title: "Themes are created",
+    text: 'We run a process to create the themes. Find out <a href="/how-it-works">how it works</a>.',
+    icon: '<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor" aria-hidden="true"><path d="M14 20.4V14.6C14 14.2686 14.2686 14 14.6 14H20.4C20.7314 14 21 14.2686 21 14.6V20.4C21 20.7314 20.7314 21 20.4 21H14.6C14.2686 21 14 20.7314 14 20.4Z" stroke="currentColor" stroke-width="1.5"></path><path d="M3 20.4V14.6C3 14.2686 3.26863 14 3.6 14H9.4C9.73137 14 10 14.2686 10 14.6V20.4C10 20.7314 9.73137 21 9.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke="currentColor" stroke-width="1.5"></path><path d="M14 9.4V3.6C14 3.26863 14.2686 3 14.6 3H20.4C20.7314 3 21 3.26863 21 3.6V9.4C21 9.73137 20.7314 10 20.4 10H14.6C14.2686 10 14 9.73137 14 9.4Z" stroke="currentColor" stroke-width="1.5"></path><path d="M3 9.4V3.6C3 3.26863 3.26863 3 3.6 3H9.4C9.73137 3 10 3.26863 10 3.6V9.4C10 9.73137 9.73137 10 9.4 10H3.6C3.26863 10 3 9.73137 3 9.4Z" stroke="currentColor" stroke-width="1.5"></path></svg>'
+  },
+  {
+    title: "View the themes",
+    text: "Sign in to view the themes and explore responses in each theme.",
+    icon: '<svg viewBox="0 0 24 24" stroke-width="1.5" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor" aria-hidden="true"><path d="M20.5 20.5L22 22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M15 18C15 19.6569 16.3431 21 18 21C18.8299 21 19.581 20.663 20.1241 20.1185C20.6654 19.5758 21 18.827 21 18C21 16.3431 19.6569 15 18 15C16.3431 15 15 16.3431 15 18Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M20 12V5.74853C20 5.5894 19.9368 5.43679 19.8243 5.32426L16.6757 2.17574C16.5632 2.06321 16.4106 2 16.2515 2H4.6C4.26863 2 4 2.26863 4 2.6V21.4C4 21.7314 4.26863 22 4.6 22H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M16 2V5.4C16 5.73137 16.2686 6 16.6 6H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+  },
+  {
+    title: "Share your experience with i.AI",
+    text: 'This tool is a prototype so to access it you need to agree to <a href="/user-research">user research</a>.',
+    icon: '<svg stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="currentColor" aria-hidden="true"><path d="M8 12L11 15L16 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 13.8214 2.48697 15.5291 3.33782 17L2.5 21.5L7 20.6622C8.47087 21.513 10.1786 22 12 22Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+  }
+] %}
+
+<div class="govuk-width-container govuk-!-margin-top-5 govuk-!-padding-top-5">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-l">How the process works</h2>
+      <ul class="iai-processlist">
+        {% for process in processList %}
+          <li class="iai-processlist__item">
+            {{process.icon|safe}}
+            <div class="iai-processlist__text">
+              <h3 class="govuk-heading-m govuk-!-margin-0">{{process.title}}</h3>
+              <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-1">{{process.text|safe}}</p>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+
 
 {% endblock %}

--- a/prototype/app/views/layouts/main.html
+++ b/prototype/app/views/layouts/main.html
@@ -1,4 +1,4 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
@@ -7,7 +7,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{% block pageTitle %}{% endblock %} – Consultation analyser - GOV.UK Prototype Kit</title>
+    <title>{% if pageTitle %}{{pageTitle}} - {% endif %}Consultation analyser - GOV.UK Prototype Kit</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
@@ -43,99 +43,153 @@
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
 {{ govukHeader({
-homepageUrl: "/",
-serviceName: serviceName,
-serviceUrl: "/"
+  homepageUrl: "/",
+  serviceName: "i.AI " + serviceName,
+  serviceUrl: "/"
 }) }}
 
 <div class="govuk-width-container">
-
-    {{ govukPhaseBanner({
+  {{ govukPhaseBanner({
     tag: {
     text: "Prototype"
     },
-    html: 'This is a new service – your <a class="govuk-link" href="#feedback">feedback</a> will help us to improve it.'
-    }) }}
-
-    {% block beforeMain %}{% endblock %}
-
-    <main class="govuk-main-wrapper" id="main-content" role="main">
-        {% if title %}
-        <h1 class="govuk-heading-l">{{title}}</h1>
-        {% endif %}
-        {% block content %}{% endblock %}
-    </main>
-
+    html: 'This is a new service – your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/GESFSF/">feedback</a> will help us to improve it.'
+  }) }}
 </div>
 
-<footer class="govuk-footer" role="contentinfo">
-    <div class="govuk-width-container">
+{#
+,
+  navigation: [
+    {
+      href: "/how-it-works",
+      text: "How it works"
+    },
+    {
+      href: "/how-it-works",
+      text: "Data schema"
+    },
+    {
+      href: "/how-it-works",
+      text: "Data sharing"
+    },
+    {
+      href: "/get-involved",
+      text: "Get involved"
+    },
+    {
+      href: "/prototype",
+      text: "Sign in"
+    }
+  ]
+#}
 
-        <div class="govuk-footer__meta">
-            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+{% set topNavLinks = [
+    {text: "Home", url: "/"},
+    {text: "How it works", url: "/how-it-works"},
+    {text: "Data schema", url: "/data-schema"},
+    {text: "Data sharing", url: "/data-sharing"},
+    {text: "Get involved", url: "/get-involved"},
+    {text: "Sign in", url: "/sign-in"}
+  ]
+%}
 
-                <h2 class="govuk-visually-hidden">Footer links</h2>
+{% set currentPage = pageTitle %}
+{% if currentPage == "" %}
+  {% set currentPage = "Home" %}
+{% endif %}
 
-                <ul class="govuk-footer__inline-list">
+<nav class="x-govuk-primary-navigation" aria-labelledby="primary-navigation-heading">
+  <div class="govuk-width-container">
+    <h2 class="govuk-visually-hidden" id="primary-navigation-heading">Navigation</h2>
+    <ul class="x-govuk-primary-navigation__list">
+      {% for link in topNavLinks %}
+        <li class="x-govuk-primary-navigation__item {% if currentPage == link.text %}x-govuk-primary-navigation__item--current {% endif %}">
+          <a class="x-govuk-primary-navigation__link" {% if currentPage == link.text %}aria-current="page"{% endif %} href="{{link.url}}">{{link.text}}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</nav>
 
-                    <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="/manage-prototype">
-                            Manage your prototype
-                        </a>
-                    </li>
+<main class="govuk-main-wrapper" id="main-content" role="main">
+    {% block content %}{% endblock %}
+</main>
 
-                    <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link" href="/manage-prototype/clear-data">
-                            Clear data
-                        </a>
-                    </li>
+{{ govukFooter({
+  navigation: [
+    {
+      title: "About Consultation analyser",
+      width: "one-half",
+      items: [
+        {
+          href: "/how-it-works",
+          text: "How it works"
+        },
+        {
+          href: "/data-schema",
+          text: "Data schema"
+        },
+        {
+          href: "/data-sharing",
+          text: "Data sharing"
+        },
+        {
+          href: "/user-research",
+          text: "User research"
+        },
+        {
+          href: "/sign-in",
+          text: "Sign in"
+        },
+        {
+          href: "/prototype",
+          text: "Prototype"
+        }
+      ]
+    },
+    {
+      title: "Contact",
+      width: "one-half",
+      items: [
+        {
+          href: "#form-link-needed",
+          text: "Register your interest"
+        },
+        {
+          href: "#slack-link-needed",
+          text: "Chat to us on Slack"
+        },
+        {
+          href: "#blog-link-needed",
+          text: "Blog"
+        }
+      ]
+    }
+  ],
+  meta: {
+    items: [
+      {
+        href: "/privacy",
+        text: "Privacy"
+      },
+      {
+        href: "/accessibility",
+        text: "Accessibility"
+      },
+      {
+        href: "/sitemap",
+        text: "Sitemap"
+      }
+    ],
+    html: 'Built by <a href="https://ai.gov.uk">Incubator for Artificial Intelligence (i.AI)</a>'
+  }
+}) }}
 
-                </ul>
-
-
-                <svg
-                        aria-hidden="true"
-                        focusable="false"
-                        class="govuk-footer__licence-logo"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 483.2 195.7"
-                        height="17"
-                        width="41"
-                >
-                    <path
-                            fill="currentColor"
-                            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-                    />
-                </svg>
-                <span class="govuk-footer__licence-description">
-
-              All content is available under the
-              <a
-                      class="govuk-footer__link"
-                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                      rel="license"
-              >Open Government Licence v3.0</a>, except where otherwise stated
-
-          </span>
-            </div>
-            <div class="govuk-footer__meta-item">
-                <a
-                        class="govuk-footer__link govuk-footer__copyright-logo"
-                        href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-                >© Crown copyright</a>
-            </div>
-        </div>
-    </div>
-</footer>
 
 <script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/kit.js"></script>
 <script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/auto-store-data.js"></script>
 <script type="module" src="/plugin-assets/govuk-frontend/dist/govuk/govuk-frontend.min.js"></script>
 <script type="module" src="/plugin-assets/govuk-frontend/dist/govuk-prototype-kit/init.js"></script>
-
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
-<script type="module" src="/public/javascripts/application.js"></script>
 
 </body>
 

--- a/prototype/app/views/layouts/signed-in.html
+++ b/prototype/app/views/layouts/signed-in.html
@@ -1,0 +1,142 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+
+<head>
+    <meta charset="utf-8">
+    <title>{% block pageTitle %}{% endblock %} – Consultation analyser - GOV.UK Prototype Kit</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <link rel="icon" sizes="48x48" href="/assets/images/favicon.ico">
+    <link rel="icon" sizes="any" href="/assets/images/favicon.svg" type="image/svg+xml">
+    <link rel="mask-icon" href="/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" href="/assets/images/govuk-icon-180.png">
+    <link rel="stylesheet" href="/public/stylesheets/application.css">
+</head>
+
+<body class="govuk-template__body">
+<script id="__bs_script__">//<![CDATA[
+        (function() {
+          try {
+            var script = document.createElement('script');
+            if ('async') {
+              script.async = true;
+            }
+            script.src = '/browser-sync/browser-sync-client.js?v=2.29.3'.replace("HOST", location.hostname);
+            if (document.body) {
+              document.body.appendChild(script);
+            } else if (document.head) {
+              document.head.appendChild(script);
+            }
+          } catch (e) {
+            console.error("Browsersync: could not append script tag", e);
+          }
+        })()
+      //]]>
+</script>
+<script>
+    document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
+</script>
+<a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
+{{ govukHeader({
+homepageUrl: "/",
+serviceName: serviceName,
+serviceUrl: "/"
+}) }}
+
+<div class="govuk-width-container">
+
+    {{ govukPhaseBanner({
+    tag: {
+    text: "Prototype"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/GESFSF/">feedback</a> will help us to improve it.'
+    }) }}
+
+    {% block beforeMain %}{% endblock %}
+
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        {% if title %}
+        <h1 class="govuk-heading-l">{{title}}</h1>
+        {% endif %}
+        {% block content %}{% endblock %}
+    </main>
+
+</div>
+
+<footer class="govuk-footer" role="contentinfo">
+    <div class="govuk-width-container">
+
+        <div class="govuk-footer__meta">
+            <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+                <h2 class="govuk-visually-hidden">Footer links</h2>
+
+                <ul class="govuk-footer__inline-list">
+
+                    <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-footer__link" href="/manage-prototype">
+                            Manage your prototype
+                        </a>
+                    </li>
+
+                    <li class="govuk-footer__inline-list-item">
+                        <a class="govuk-footer__link" href="/manage-prototype/clear-data">
+                            Clear data
+                        </a>
+                    </li>
+
+                </ul>
+
+
+                <svg
+                        aria-hidden="true"
+                        focusable="false"
+                        class="govuk-footer__licence-logo"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 483.2 195.7"
+                        height="17"
+                        width="41"
+                >
+                    <path
+                            fill="currentColor"
+                            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+                    />
+                </svg>
+                <span class="govuk-footer__licence-description">
+
+              All content is available under the
+              <a
+                      class="govuk-footer__link"
+                      href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                      rel="license"
+              >Open Government Licence v3.0</a>, except where otherwise stated
+
+          </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+                <a
+                        class="govuk-footer__link govuk-footer__copyright-logo"
+                        href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
+                >© Crown copyright</a>
+            </div>
+        </div>
+    </div>
+</footer>
+
+<script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/kit.js"></script>
+<script src="/plugin-assets/govuk-prototype-kit/lib/assets/javascripts/auto-store-data.js"></script>
+<script type="module" src="/plugin-assets/govuk-frontend/dist/govuk/govuk-frontend.min.js"></script>
+<script type="module" src="/plugin-assets/govuk-frontend/dist/govuk-prototype-kit/init.js"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
+<script type="module" src="/public/javascripts/application.js"></script>
+
+</body>
+
+</html>

--- a/prototype/app/views/prototype.html
+++ b/prototype/app/views/prototype.html
@@ -1,0 +1,36 @@
+{% extends "layouts/main.html" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set pageTitle = "Prototype" %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Consultations frontend prototype</h1>
+
+      <h2 class="govuk-heading-m">Demo consultation</h2>
+      <p>The demo consultation shows how each page will look and what features will be available.</p>
+      {{ govukButton({
+        text: "View consultation",
+        href: "/demo-consultation",
+        isStartButton: true
+      }) }}
+
+      <h2 class="govuk-heading-m govuk-!-margin-top-3">Upload consultation</h2>
+      <p>This is an MVP version just for use by the i.AI team currently. Longer term this can be expanded to be useable by others. At which point we'll need to consider what additional data/instructions will be required.</p>
+      {{ govukButton({
+        text: "Upload consultation",
+        classes: "govuk-button--secondary",
+        href: "/upload"
+      }) }}
+
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/prototype/app/views/question-responses.html
+++ b/prototype/app/views/question-responses.html
@@ -1,4 +1,4 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/prototype/app/views/question-summary.html
+++ b/prototype/app/views/question-summary.html
@@ -1,4 +1,4 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/prototype/app/views/respondent.html
+++ b/prototype/app/views/respondent.html
@@ -1,4 +1,4 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/prototype/app/views/upload-success.html
+++ b/prototype/app/views/upload-success.html
@@ -1,4 +1,4 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}

--- a/prototype/app/views/upload.html
+++ b/prototype/app/views/upload.html
@@ -1,4 +1,4 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}

--- a/prototype/package-lock.json
+++ b/prototype/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "2.0.1",
+        "@x-govuk/govuk-prototype-components": "^3.0.4",
         "govuk-frontend": "5.3.0",
         "govuk-prototype-kit": "13.16.2"
       }
@@ -94,6 +95,24 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.12.tgz",
       "integrity": "sha512-bZcOkJ6uWrL0Qb2NAWKa7TBU+mJHPzhx9jjLL1KHF+XpzEcR7EXHvjbHlGtR/IsP1vyPrehuS6XqkmaePy//mg=="
     },
+    "node_modules/@x-govuk/govuk-prototype-components": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-3.0.4.tgz",
+      "integrity": "sha512-MidplaiFo+mgBRUZCsUwHjCGvhMzXEE7I+gPuAY7GG6NpXHUktsqCIRDDSaNu/twrECzuui7OywmdrRyzAUEiA==",
+      "dependencies": {
+        "accessible-autocomplete": "^2.0.4",
+        "eventslibjs": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "govuk-prototype-kit": "^13.14.1"
+      },
+      "peerDependencies": {
+        "govuk-frontend": "^5.0.0"
+      }
+    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -114,6 +133,14 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accessible-autocomplete": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
+      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "dependencies": {
+        "preact": "^8.3.1"
       }
     },
     "node_modules/aggregate-error": {
@@ -1081,6 +1108,11 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/eventslibjs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventslibjs/-/eventslibjs-1.2.0.tgz",
+      "integrity": "sha512-nui7FHXHeeZjWkQ1dZ4R3RchkT+164+y1/puiOY1Zc3CPU9W8XzAzdhqvuVQ4EJt7F/W94O5U26/oVFpBOPY3w=="
     },
     "node_modules/express": {
       "version": "4.19.2",
@@ -2357,6 +2389,12 @@
         "node": ">=0.4",
         "npm": ">=1.0.0"
       }
+    },
+    "node_modules/preact": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
+      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
+      "hasInstallScript": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",

--- a/prototype/package.json
+++ b/prototype/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
+    "@x-govuk/govuk-prototype-components": "^3.0.4",
     "govuk-frontend": "5.3.0",
     "govuk-prototype-kit": "13.16.2"
   }


### PR DESCRIPTION
## Context

This is the first in a series of updates for the new homepage content. This covers the homepage and the menu structure.

Currently the other menu items are broken links. I think this is okay because:
* This is on the prototype only
* Those pages will be coming very soon (possibly today)

## Changes proposed in this pull request

* Updating the homepage to this:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/0b85fc37-c464-4b16-83e8-8f55ffcf53a0)

* Moving the prototype page to `/prototype` (there is also a footer link to this)

## Guidance to review

* Please check the content looks and reads okay. @judewebby is likely to be updating it, this is the starting point.

## Link to JIRA ticket
https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-81