### PR TITLE
Fix/dependabot stop build

### DIFF
--- a/.github/.github.env
+++ b/.github/.github.env
@@ -1,5 +1,5 @@
 # github specific
-EC2_INSTANCE_TYPE=t3.large
+EC2_INSTANCE_TYPE=t3.xlarge
 RUNNER_SIZE=large
 
 # App related

--- a/.github/workflows/build-gh.yml
+++ b/.github/workflows/build-gh.yml
@@ -1,12 +1,9 @@
 
 name: build
 on:
-  workflow_run:
-    workflows: ['Tests']
-    types:
-      - completed
-    branches: "**"
-
+  push:
+    branches-ignore:
+      - "dependabot/**"
 
 jobs:
   set-vars:
@@ -21,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
       - id: export
         run: |
           . ./.github/.github.env

--- a/.github/workflows/build-gh.yml
+++ b/.github/workflows/build-gh.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
       - id: export
         run: |
           . ./.github/.github.env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - main
+      - "**"
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "**"
-  pull_request:
-    branches:
-      - main
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,10 @@ name: Tests
 on:
   push:
     branches:
-      - "**"
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## Context
Revert to build after every push to GitHub and prevent `dependabot` from running the build actions. If dependabot triggers a build actions it will not pass because the action will not have access to github secrets

### Alternative solutions explored
Using `workflow_runs` after the `Tests` workflow has run: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

However this comes with it's own complications as `workflow_runs` only trigger from the default branch: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run

One could work around this by using the below code, however this adds significant additional complexity and can be unclear what branch has built and been released when looking at the GitHub Actions tab.

```
steps:
      - uses: actions/checkout
        with:
          ref: ${{ github.event.pull_request.head.sha }}
```