### PR TITLE
Feature/respondents switch

### DIFF
--- a/prototype/app/views/demo-consultation.html
+++ b/prototype/app/views/demo-consultation.html
@@ -112,60 +112,6 @@
 
     {% endset %}
 
-    {% set tab3 %}
-      <h2 class="govuk-heading-m">Contacts</h2>
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">DOSaC:</h3>
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: {
-              text: "Policy"
-            },
-            value: {
-              text: "firstname.lastname@dosac.gov.uk"
-            }
-          },
-          {
-            key: {
-              text: "Analyst"
-            },
-            value: {
-              text: "firstname.lastname@dosac.gov.uk"
-            }
-          },
-          {
-            key: {
-              text: "Data Science"
-            },
-            value: {
-              text: "firstname.lastname@dosac.gov.uk"
-            }
-          }
-        ]
-      }) }}
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-1">10DS:</h3>
-      {{ govukSummaryList({
-        rows: [
-          {
-            key: {
-              text: "Analyst"
-            },
-            value: {
-              text: "firstname.lastname@no10.gov.uk"
-            }
-          },
-          {
-            key: {
-              text: "Social Affairs Lead"
-            },
-            value: {
-              text: "firstname.lastname@no10.gov.uk"
-            }
-          }
-        ]
-      }) }}
-    {% endset %}
-
     {{ govukTabs({
       items: [
         {
@@ -180,13 +126,6 @@
           id: "findings",
           panel: {
             html: tab2
-          }
-        },
-        {
-          label: "Contacts",
-          id: "contacts",
-          panel: {
-            html: tab3
           }
         }
       ]

--- a/prototype/app/views/demo-consultation.html
+++ b/prototype/app/views/demo-consultation.html
@@ -112,24 +112,30 @@
 
     {% endset %}
 
-    {{ govukTabs({
-      items: [
-        {
-          label: "Responses processed",
-          id: "responses",
-          panel: {
-            html: tab1
+    {% if data.respondents == "true" %}
+      {{ govukTabs({
+        items: [
+          {
+            label: "Responses processed",
+            id: "responses",
+            panel: {
+              html: tab1
+            }
+          },
+          {
+            label: "Key findings",
+            id: "findings",
+            panel: {
+              html: tab2
+            }
           }
-        },
-        {
-          label: "Key findings",
-          id: "findings",
-          panel: {
-            html: tab2
-          }
-        }
-      ]
-    }) }}
+        ]
+      }) }}
+    {% else %}
+      <div class="govuk-!-margin-bottom-7">
+        {{ tab2 | safe }}
+      </div>
+    {% endif %}
 
 
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0">Questions</h2>

--- a/prototype/app/views/prototype.html
+++ b/prototype/app/views/prototype.html
@@ -1,35 +1,42 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/signed-in.html" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% set pageTitle = "Prototype" %}
+{% set pageName="Home" %}
+
+{% block pageTitle %}Home{% endblock %}
 
 {% block content %}
 
-<div class="govuk-width-container">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Consultations frontend prototype</h1>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">Consultations frontend prototype</h1>
-
-      <h2 class="govuk-heading-m">Demo consultation</h2>
-      <p>The demo consultation shows how each page will look and what features will be available.</p>
+    <h2 class="govuk-heading-m">Demo consultation</h2>
+    <p>The demo consultation shows how each page will look and what features will be available.</p>
+    <div class="govuk-button-group">
       {{ govukButton({
         text: "View consultation",
-        href: "/demo-consultation",
+        href: "/demo-consultation?respondents=true",
         isStartButton: true
       }) }}
-
-      <h2 class="govuk-heading-m govuk-!-margin-top-3">Upload consultation</h2>
-      <p>This is an MVP version just for use by the i.AI team currently. Longer term this can be expanded to be useable by others. At which point we'll need to consider what additional data/instructions will be required.</p>
       {{ govukButton({
-        text: "Upload consultation",
-        classes: "govuk-button--secondary",
-        href: "/upload"
+        text: "View with no respondents",
+        href: "/demo-consultation?respondents=false",
+        isStartButton: true,
+        classes: "govuk-button--secondary"
       }) }}
-
     </div>
+
+    <h2 class="govuk-heading-m govuk-!-margin-top-3">Upload consultation</h2>
+    <p>This is an MVP version just for use by the i.AI team currently. Longer term this can be expanded to be useable by others. At which point we'll need to consider what additional data/instructions will be required.</p>
+    {{ govukButton({
+      text: "Upload consultation",
+      classes: "govuk-button--secondary",
+      href: "/upload"
+    }) }}
+
   </div>
 </div>
 

--- a/prototype/app/views/question-responses.html
+++ b/prototype/app/views/question-responses.html
@@ -74,118 +74,122 @@
           ]
         }) }}
 
-        {{ govukSelect({
-          id: "filter-location",
-          name: "location",
-          label: {
-            text: "Location"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
-            },
-            {
-              value: "england",
-              text: "England"
-            },
-            {
-              value: "scotland",
-              text: "Scotland"
-            },
-            {
-              value: "wales",
-              text: "Wales"
-            },
-            {
-              value: "northern-ireland",
-              text: "Northern Ireland"
-            }
-          ]
-        }) }}
+        {% if data.respondents == "true" %}
 
-        {{ govukSelect({
-          id: "filter-age",
-          name: "age",
-          label: {
-            text: "Age group"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
+          {{ govukSelect({
+            id: "filter-location",
+            name: "location",
+            label: {
+              text: "Location"
             },
-            {
-              value: "13-14",
-              text: "13 - 14"
-            },
-            {
-              value: "15-17",
-              text: "15 - 17"
-            },
-            {
-              value: "18-24",
-              text: "18 - 24"
-            },
-            {
-              value: "25-34",
-              text: "25 - 34"
-            },
-            {
-              value: "35-44",
-              text: "35 - 44"
-            },
-            {
-              value: "45-54",
-              text: "45 - 54"
-            },
-            {
-              value: "55-64",
-              text: "55 - 64"
-            },
-            {
-              value: "65-74",
-              text: "65 - 74"
-            },
-            {
-              value: "75plus",
-              text: "75 or above"
-            },
-            {
-              value: "unknown",
-              text: "Prefer not to say"
-            }
-          ]
-        }) }}
+            items: [
+              {
+                value: "all",
+                text: "All",
+                selected: true
+              },
+              {
+                value: "england",
+                text: "England"
+              },
+              {
+                value: "scotland",
+                text: "Scotland"
+              },
+              {
+                value: "wales",
+                text: "Wales"
+              },
+              {
+                value: "northern-ireland",
+                text: "Northern Ireland"
+              }
+            ]
+          }) }}
 
-        {{ govukSelect({
-          id: "filter-capacity",
-          name: "capacity",
-          label: {
-            text: "Capacity"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
+          {{ govukSelect({
+            id: "filter-age",
+            name: "age",
+            label: {
+              text: "Age group"
             },
-            {
-              value: "personal",
-              text: "Personal"
+            items: [
+              {
+                value: "all",
+                text: "All",
+                selected: true
+              },
+              {
+                value: "13-14",
+                text: "13 - 14"
+              },
+              {
+                value: "15-17",
+                text: "15 - 17"
+              },
+              {
+                value: "18-24",
+                text: "18 - 24"
+              },
+              {
+                value: "25-34",
+                text: "25 - 34"
+              },
+              {
+                value: "35-44",
+                text: "35 - 44"
+              },
+              {
+                value: "45-54",
+                text: "45 - 54"
+              },
+              {
+                value: "55-64",
+                text: "55 - 64"
+              },
+              {
+                value: "65-74",
+                text: "65 - 74"
+              },
+              {
+                value: "75plus",
+                text: "75 or above"
+              },
+              {
+                value: "unknown",
+                text: "Prefer not to say"
+              }
+            ]
+          }) }}
+
+          {{ govukSelect({
+            id: "filter-capacity",
+            name: "capacity",
+            label: {
+              text: "Capacity"
             },
-            {
-              value: "professional",
-              text: "Professional"
-            },
-            {
-              value: "organisation",
-              text: "Organisation"
-            }
-          ]
-        }) }}
+            items: [
+              {
+                value: "all",
+                text: "All",
+                selected: true
+              },
+              {
+                value: "personal",
+                text: "Personal"
+              },
+              {
+                value: "professional",
+                text: "Professional"
+              },
+              {
+                value: "organisation",
+                text: "Organisation"
+              }
+            ]
+          }) }}
+
+        {% endif %}
 
         {{ govukButton({
           text: "Apply filters",
@@ -211,7 +215,9 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Closed response</th>
           <th scope="col" class="govuk-table__header">Open response</th>
-          <th scope="col" class="govuk-table__header" style="width: 9rem;">Actions</th>
+          {% if data.respondents == "true" %}
+            <th scope="col" class="govuk-table__header" style="width: 9rem;">Actions</th>
+          {% endif %}
         </tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -220,16 +226,11 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">Agree</td>
             <td class="govuk-table__cell">{{response}}</td>
-            <td class="govuk-table__cell">
-              <a href="/respondent">View respondent</a>
-              {#
-              {{ govukButton({
-                text: "View respondent",
-                classes: "govuk-button--secondary",
-                href: "/respondent"
-              }) }}
-              #}
-            </td>
+            {% if data.respondents == "true" %}
+              <td class="govuk-table__cell">
+                <a href="/respondent">View respondent</a>
+              </td>
+            {% endif %}
           </tr>
         {% endfor %}
       </tbody>

--- a/prototype/app/views/question-summary.html
+++ b/prototype/app/views/question-summary.html
@@ -118,118 +118,122 @@
           ]
         }) }}
 
-        {{ govukSelect({
-          id: "filter-location",
-          name: "location",
-          label: {
-            text: "Location"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
-            },
-            {
-              value: "england",
-              text: "England"
-            },
-            {
-              value: "scotland",
-              text: "Scotland"
-            },
-            {
-              value: "wales",
-              text: "Wales"
-            },
-            {
-              value: "northern-ireland",
-              text: "Northern Ireland"
-            }
-          ]
-        }) }}
+        {% if data.respondents == "true" %}
 
-        {{ govukSelect({
-          id: "filter-age",
-          name: "age",
-          label: {
-            text: "Age group"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
+          {{ govukSelect({
+            id: "filter-location",
+            name: "location",
+            label: {
+              text: "Location"
             },
-            {
-              value: "13-14",
-              text: "13 - 14"
-            },
-            {
-              value: "15-17",
-              text: "15 - 17"
-            },
-            {
-              value: "18-24",
-              text: "18 - 24"
-            },
-            {
-              value: "25-34",
-              text: "25 - 34"
-            },
-            {
-              value: "35-44",
-              text: "35 - 44"
-            },
-            {
-              value: "45-54",
-              text: "45 - 54"
-            },
-            {
-              value: "55-64",
-              text: "55 - 64"
-            },
-            {
-              value: "65-74",
-              text: "65 - 74"
-            },
-            {
-              value: "75plus",
-              text: "75 or above"
-            },
-            {
-              value: "unknown",
-              text: "Prefer not to say"
-            }
-          ]
-        }) }}
+            items: [
+              {
+                value: "all",
+                text: "All",
+                selected: true
+              },
+              {
+                value: "england",
+                text: "England"
+              },
+              {
+                value: "scotland",
+                text: "Scotland"
+              },
+              {
+                value: "wales",
+                text: "Wales"
+              },
+              {
+                value: "northern-ireland",
+                text: "Northern Ireland"
+              }
+            ]
+          }) }}
 
-        {{ govukSelect({
-          id: "filter-capacity",
-          name: "capacity",
-          label: {
-            text: "Capacity"
-          },
-          items: [
-            {
-              value: "all",
-              text: "All",
-              selected: true
+          {{ govukSelect({
+            id: "filter-age",
+            name: "age",
+            label: {
+              text: "Age group"
             },
-            {
-              value: "personal",
-              text: "Personal"
+            items: [
+              {
+                value: "all",
+                text: "All",
+                selected: true
+              },
+              {
+                value: "13-14",
+                text: "13 - 14"
+              },
+              {
+                value: "15-17",
+                text: "15 - 17"
+              },
+              {
+                value: "18-24",
+                text: "18 - 24"
+              },
+              {
+                value: "25-34",
+                text: "25 - 34"
+              },
+              {
+                value: "35-44",
+                text: "35 - 44"
+              },
+              {
+                value: "45-54",
+                text: "45 - 54"
+              },
+              {
+                value: "55-64",
+                text: "55 - 64"
+              },
+              {
+                value: "65-74",
+                text: "65 - 74"
+              },
+              {
+                value: "75plus",
+                text: "75 or above"
+              },
+              {
+                value: "unknown",
+                text: "Prefer not to say"
+              }
+            ]
+          }) }}
+
+          {{ govukSelect({
+            id: "filter-capacity",
+            name: "capacity",
+            label: {
+              text: "Capacity"
             },
-            {
-              value: "professional",
-              text: "Professional"
-            },
-            {
-              value: "organisation",
-              text: "Organisation"
-            }
-          ]
-        }) }}
+            items: [
+              {
+                value: "all",
+                text: "All",
+                selected: true
+              },
+              {
+                value: "personal",
+                text: "Personal"
+              },
+              {
+                value: "professional",
+                text: "Professional"
+              },
+              {
+                value: "organisation",
+                text: "Organisation"
+              }
+            ]
+          }) }}
+
+        {% endif %}
 
         {{ govukButton({
           text: "Apply filters",


### PR DESCRIPTION
__Don't merge until https://github.com/i-dot-ai/consultation-analyser/pull/97 and https://github.com/i-dot-ai/consultation-analyser/pull/103 are merged, and then this has been rebased__

## Context

Because MVP v1 won't have respondent data, this allows us to show the prototype with and without respondent data.

## Changes proposed in this pull request

* Removed the contacts tab (as this isn't required at all)
* Add options to the menu page to view the consultation either with or without respondent data
* If viewing without respondent data:
  * The tabs are removed, and the "Responses processed" section isn't shown
  * Demographic filters are removed from both the "Question summary" and the "Response explorer" pages
  * The "View respondent" links are removed

## Guidance to review

* Check both options, and that anything related to respondent data is only shown at the correct time.

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-140
