### PR TITLE
Try and group dependabot PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,35 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    groups:
+      pip-updates:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      npm-updates:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/prototype"
     schedule:
       interval: "weekly"
+    groups:
+      prototype-updates:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Will be easier if dependabot updates are grouped.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Group the dependabot updates. Set Python updates to come daily so we can see if this works sooner rather than later! (Can change back later.)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does this seem ok?

Docs here: 
- https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo