### PR TITLE
Fix asssets in deployed envs, speed up build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,8 @@
 
 **/.build-harness
 **/build-harness
+
+frontend/CACHE
+frontend/govuk-assets
+frontend/admin
+frontend/django_extensions

--- a/consultation_analyser/consultations/ml_pipeline.py
+++ b/consultation_analyser/consultations/ml_pipeline.py
@@ -3,12 +3,6 @@ from uuid import UUID
 
 import numpy as np
 import pandas as pd
-from bertopic import BERTopic
-from bertopic.vectorizers import ClassTfidfTransformer
-from hdbscan import HDBSCAN
-from sentence_transformers import SentenceTransformer
-from sklearn.feature_extraction.text import CountVectorizer
-from umap.umap_ import UMAP
 
 from consultation_analyser.consultations import models
 
@@ -18,6 +12,8 @@ RANDOM_STATE = 12  # For reproducibility
 def get_embeddings_for_question(
     answers_list: List[Dict[str, Union[UUID, str]]], embedding_model_name: str = "thenlper/gte-small"
 ) -> List[Dict[str, Union[UUID, str, np.ndarray]]]:
+    from sentence_transformers import SentenceTransformer
+
     free_text_responses = [answer["free_text"] for answer in answers_list]
     embedding_model = SentenceTransformer(embedding_model_name)
     embeddings = embedding_model.encode(free_text_responses)
@@ -26,7 +22,13 @@ def get_embeddings_for_question(
     return answers_list_with_embeddings
 
 
-def get_topic_model(answers_list_with_embeddings: List[Dict[str, Union[UUID, str, np.ndarray]]]) -> BERTopic:
+def get_topic_model(answers_list_with_embeddings: List[Dict[str, Union[UUID, str, np.ndarray]]]):
+    from bertopic import BERTopic
+    from bertopic.vectorizers import ClassTfidfTransformer
+    from hdbscan import HDBSCAN
+    from sklearn.feature_extraction.text import CountVectorizer
+    from umap.umap_ import UMAP
+
     free_text_responses_list = [answer["free_text"] for answer in answers_list_with_embeddings]
     embeddings_list = [answer["embedding"] for answer in answers_list_with_embeddings]
     embeddings = np.array(embeddings_list)
@@ -46,7 +48,7 @@ def get_topic_model(answers_list_with_embeddings: List[Dict[str, Union[UUID, str
     return topic_model
 
 
-def get_answers_and_topics(topic_model: BERTopic, answers_list: List[Dict[str, Union[UUID, str]]]) -> pd.DataFrame:
+def get_answers_and_topics(topic_model, answers_list: List[Dict[str, Union[UUID, str]]]) -> pd.DataFrame:
     # Answers free text/IDs need to be in the same order
     free_text_responses = [answer["free_text"] for answer in answers_list]
     answers_id_list = [answer["id"] for answer in answers_list]

--- a/consultation_analyser/gunicorn.py
+++ b/consultation_analyser/gunicorn.py
@@ -1,4 +1,4 @@
-workers = 5
+workers = 1
 bind = "0.0.0.0:8000"
 accesslog = "-"
 errorlog = "-"

--- a/consultation_analyser/support_console/views.py
+++ b/consultation_analyser/support_console/views.py
@@ -5,7 +5,7 @@ from django.contrib.messages import get_messages
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 
-from consultation_analyser.consultations import dummy_data, ml_pipeline, models
+from consultation_analyser.consultations import dummy_data, models
 from consultation_analyser.hosting_environment import HostingEnvironment
 
 
@@ -42,6 +42,8 @@ def show_consultation(request: HttpRequest, consultation_slug: str) -> HttpRespo
             answer__question__section__consultation=consultation
         ).exists()
         if not themes_already_exist:
+            from consultation_analyser.consultations import ml_pipeline
+
             ml_pipeline.save_themes_for_consultation(consultation_id=consultation.id)
     # TODO - pass through messages - "themes created" or "consultation already has themes"
     context = {"consultation": consultation}

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
 venv/bin/django-admin migrate
+venv/bin/django-admin collectstatic --noinput
 venv/bin/django-admin compress --force --engine jinja2
+
 exec venv/bin/gunicorn -c ./consultation_analyser/gunicorn.py consultation_analyser.wsgi


### PR DESCRIPTION
## Context

Assets were broken in dev, masked by the fact that local docker builds copied local assets into the container.

This PR also speeds up the app by moving some requires into functions, and incorporates a small infra fix

## Changes proposed in this pull request

- add assets folders to dockerignore
- build assets in the docker entrypoint
- reduce gunicorn workers to 1 so local runs better — we can tweak this in prod once we have traffic/load testing

## Guidance to review

Does it build here/ on your machine?

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo