### PR TITLE
Set hostname in CSRF_TRUSTED_ORIGINS

### DIFF
--- a/consultation_analyser/settings/production.py
+++ b/consultation_analyser/settings/production.py
@@ -1,1 +1,3 @@
 from consultation_analyser.settings.base import *  # noqa
+
+CSRF_TRUSTED_ORIGINS = ["https://" + env("DOMAIN_NAME")]


### PR DESCRIPTION
## Context

CSRF is broken in deployed environments if we don't set `CSRF_TRUSTED_ORIGINS`

## Changes proposed in this pull request

Set it to the `DOMAIN_NAME` value from terraform.

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo