### PR TITLE
Add filters to question summary page

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultation.html
+++ b/consultation_analyser/consultations/jinja2/consultation.html
@@ -17,7 +17,7 @@
             <span class="govuk-visually-hidden"> - {{ q.text }}</span>
           </a>
           {# TO DO: put the following href in the same format as above (once the question-detail PR has been merged) #}
-          <a href="/consultations/{{ q.section.consultation.slug }}/sections/{{ q.section.slug }}/questions/{{ q.slug }}" class="govuk-link govuk-link--no-visited-state">
+          <a href="/consultations/{{ q.section.consultation.slug }}/sections/{{ q.section.slug }}/responses/{{ q.slug }}" class="govuk-link govuk-link--no-visited-state">
             Explore responses
             <span class="govuk-visually-hidden"> - {{ q.text }}</span>
           </a>

--- a/consultation_analyser/consultations/jinja2/show_question.html
+++ b/consultation_analyser/consultations/jinja2/show_question.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
 {% set page_title = "Question summary - dummy page" %}
 
@@ -10,9 +11,9 @@
       <h1 class="govuk-heading-l">{{ page_title }}</h1>
       <p class="govuk-body">{{ question.text }}</p>
 
-      {% if question.multiple_choice_options %}
+      {% if multiple_choice_responses %}
         <dl class="govuk-summary-list">
-          {% for response in question.multiple_choice_response_counts() %}
+          {% for response in multiple_choice_responses %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 {{ response.answer }}
@@ -26,10 +27,10 @@
       {% endif %}
     </div>
 
-    {% if question.multiple_choice_options %}
+    {% if multiple_choice_responses %}
       <div class="govuk-grid-column-one-third govuk-!-padding-0">
         <donut-chart>
-          {% for response in question.multiple_choice_response_counts() %}
+          {% for response in multiple_choice_responses %}
             <chart-item data-label="{{ response.answer }}" data-count="{{ response.percent }}"></chart-item>
           {% endfor %}
         </donut-chart>
@@ -38,48 +39,97 @@
 
   </div>
 
+  <div class="govuk-grid-row">
 
-  <table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--s">
-      <h2 class="govuk-!-margin-bottom-2 govuk-!-margin-top-0">Prevalent themes</h2>
-    </caption>
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Theme</th>
-        <th scope="col" class="govuk-table__header">Number of respondents</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      {% for theme in themes %}
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <details class="govuk-details govuk-!-margin-bottom-0">
-              <summary class="govuk-details__summary govuk-!-margin-top-1">
-                <span class="govuk-details__summary-text">{{ theme.label }}</span>
-              </summary>
-              <div class="govuk-details__text">
-                <p>{{ theme.summary }}</p>
-                <p class="govuk-!-margin-bottom-0">This theme has the following keywords:</p>
-                <ul class="iai-inline-list govuk-!-margin-top-1">
-                  {% for word in theme.keywords %}
-                    <li class="iai-inline-list__item">{{ word }}</li>
-                  {% endfor %}
-                </ul>
-              </div>
-            </details>
-          </td>
-          <td class="govuk-table__cell">
-            <bar-animation class="iai-bar">
-              <span class="iai-bar__value">{{ theme.answer_count }}</span>
-              {% if theme.answer_count and highest_theme_count %}
-                <span class="iai-bar__bar js-bar" style="width: {{ (theme.answer_count / highest_theme_count) * 100 }}%;"></span>
-              {% endif %}
-            </bar-animation>
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+    <div class="govuk-grid-column-one-third">
+      <div class="iai-filters govuk-!-margin-bottom-5">
+        <h2 class="govuk-heading-m">Filters</h2>
+        <form>
+
+          <div class="govuk-form-group">
+              <label class="govuk-label" for="theme">
+                Theme
+              </label>
+              <select class="govuk-select" id="theme" name="theme">
+                <option {% if applied_filters.theme == "All" %}selected{% endif %}>All</option>
+                {% for theme in themes %}
+                  <option value="{{ theme.id }}" {% if applied_filters.theme|string == theme.id|string %}selected{% endif %}>{{ theme.label }}</option>
+                {% endfor %}
+                {#<option {% if applied_filters.theme == "No theme" %}selected{% endif %}>No theme</option>#}
+              </select>
+            </div>
+
+          {% if question.multiple_choice_options %}
+            <div class="govuk-form-group">
+              <label class="govuk-label" for="opinion">
+                Opinion
+              </label>
+              <select class="govuk-select" id="opinion" name="opinion">
+                <option {% if applied_filters.opinion == "All" %}selected{% endif %}>All</option>
+                {% for option in question.multiple_choice_options %}
+                  <option {% if applied_filters.opinion == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          {% endif %}
+
+          {{ govukButton({
+            "text": "Apply filters",
+            "classes": "govuk-!-margin-bottom-2"
+          }) }}
+          <div class="govuk-!-padding-2">
+            <a class="govuk-body" href="?">Clear filters</a>
+          </div>
+
+        </form>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--s">
+          <h2 class="govuk-!-margin-bottom-2 govuk-!-margin-top-0">Prevalent themes</h2>
+        </caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Theme</th>
+            <th scope="col" class="govuk-table__header">Number of respondents</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for theme in themes %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <details class="govuk-details govuk-!-margin-bottom-0">
+                  <summary class="govuk-details__summary govuk-!-margin-top-1">
+                    <span class="govuk-details__summary-text">{{ theme.label }}</span>
+                  </summary>
+                  <div class="govuk-details__text">
+                    <p>{{ theme.summary }}</p>
+                    <p class="govuk-!-margin-bottom-0">This theme has the following keywords:</p>
+                    <ul class="iai-inline-list govuk-!-margin-top-1">
+                      {% for word in theme.keywords %}
+                        <li class="iai-inline-list__item">{{ word }}</li>
+                      {% endfor %}
+                    </ul>
+                  </div>
+                </details>
+              </td>
+              <td class="govuk-table__cell">
+                <bar-animation class="iai-bar">
+                  <span class="iai-bar__value">{{ theme.answer_count }}</span>
+                  {% if theme.answer_count and highest_theme_count %}
+                    <span class="iai-bar__bar js-bar" style="width: {{ (theme.answer_count / highest_theme_count) * 100 }}%;"></span>
+                  {% endif %}
+                </bar-animation>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
   {% compress js %}

--- a/consultation_analyser/consultations/jinja2/show_responses.html
+++ b/consultation_analyser/consultations/jinja2/show_responses.html
@@ -32,10 +32,10 @@
               </label>
               <select class="govuk-select" id="theme" name="theme">
                 <option {% if applied_filters.theme == "All" %}selected{% endif %}>All</option>
-                {% for theme in themes_for_question %}
+                {% for theme in themes %}
                   <option value="{{ theme.id }}" {% if applied_filters.theme|string == theme.id|string %}selected{% endif %}>{{ theme.label }}</option>
                 {% endfor %}
-                <option {% if applied_filters.theme == "No theme" %}selected{% endif %}>No theme</option>
+                {#<option {% if applied_filters.theme == "No theme" %}selected{% endif %}>No theme</option>#}
               </select>
             </div>
 
@@ -85,7 +85,7 @@
             <tr class="govuk-table__row govuk-body-s">
               {% if question.multiple_choice_options %}
                 <td class="govuk-table__cell">
-                  {{ response.multiple_choice_responses }}
+                  {{ response.multiple_choice_responses[0] }}
                 </td>
               {% endif %}
               <td class="govuk-table__cell">

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -54,24 +54,6 @@ class Question(UUIDPrimaryKeyModel, TimeStampedModel):
         count: int
         percent: float
 
-    def multiple_choice_response_counts(self) -> list[MultipleChoiceResponseCount]:
-        if not self.multiple_choice_options:
-            return []
-
-        responses: list = reduce(
-            lambda resps, answer: resps + answer.multiple_choice_responses, self.answer_set.all(), []
-        )
-        counter = Counter(responses)
-
-        # this does not support more than one choice per response
-        total_response_count = len(responses)
-        response_counts = []
-        for answer, count in counter.items():
-            percent = round((count / total_response_count) * 100)
-            response_counts.append(self.MultipleChoiceResponseCount(answer=answer, count=count, percent=percent))
-
-        return response_counts
-
     class Meta(UUIDPrimaryKeyModel.Meta, TimeStampedModel.Meta):
         constraints = [
             models.UniqueConstraint(fields=["slug", "section"], name="unique_question_section"),

--- a/consultation_analyser/consultations/views/filters.py
+++ b/consultation_analyser/consultations/views/filters.py
@@ -1,0 +1,36 @@
+from django.db.models import Count, QuerySet
+from django.http import HttpRequest
+
+from .. import models
+
+
+def get_applied_filters(request: HttpRequest) -> dict[str, str]:
+    return {
+        "keyword": request.GET.get("keyword", ""),
+        "theme": request.GET.get("theme", "All"),
+        "opinion": request.GET.get("opinion", "All"),
+    }
+
+
+def get_filtered_responses(question: models.Question, applied_filters: dict[str, str]) -> QuerySet:
+    queryset = models.Answer.objects.filter(question=question, free_text__icontains=applied_filters["keyword"])
+    if applied_filters["theme"] != "All":
+        queryset = queryset.filter(theme=applied_filters["theme"])
+    # TO DO: handle answers with "No theme"
+    if applied_filters["opinion"] != "All":
+        queryset = queryset.filter(multiple_choice_responses__contains=applied_filters["opinion"])
+    return queryset
+
+
+def get_filtered_themes(
+    question: models.Question, filtered_answers: QuerySet, applied_filters: dict[str, str]
+) -> QuerySet:
+    queryset = models.Theme.objects.filter(answer__question=question).annotate(answer_count=Count("answer"))
+    if applied_filters["theme"] != "All":
+        queryset = queryset.filter(id=applied_filters["theme"])
+    if applied_filters["opinion"] != "All":
+        unique_themes = filtered_answers.values("theme").distinct()
+        unique_themes_list = [item["theme"] for item in unique_themes]
+        queryset = queryset.filter(id__in=unique_themes_list)
+    # TO DO: handle answers with "No theme"
+    return queryset

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -1,10 +1,10 @@
-from django.core.paginator import Paginator
-from django.db.models import Count, Max
+from django.db.models import Max
 from django.http import HttpRequest
 from django.shortcuts import render
 from waffle.decorators import waffle_switch
 
 from .. import models
+from .filters import get_applied_filters, get_filtered_responses, get_filtered_themes
 
 
 @waffle_switch("CONSULTATION_PROCESSING")
@@ -12,16 +12,26 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
     question = models.Question.objects.get(
         slug=question_slug, section__slug=section_slug, section__consultation__slug=consultation_slug
     )
-    themes_for_question = models.Theme.objects.filter(answer__question=question).annotate(answer_count=Count("answer"))
+    applied_filters = get_applied_filters(request)
+    responses = get_filtered_responses(question, applied_filters)
+    filtered_themes = get_filtered_themes(question, responses, applied_filters)
 
     # Get counts
-    total_responses = models.Answer.objects.filter(question=question).count()
-    highest_theme_count = themes_for_question.aggregate(Max("answer_count"))["answer_count__max"]
+    total_responses = responses.count()
+    multiple_choice_responses = []
+    if total_responses:
+        for option in question.multiple_choice_options:
+            count = responses.filter(multiple_choice_responses__contains=option).count()
+            multiple_choice_responses.append({"answer": option, "percent": round((count / total_responses) * 100)})
+    highest_theme_count = filtered_themes.aggregate(Max("answer_count"))["answer_count__max"]
 
     context = {
         "question": question,
-        "themes": themes_for_question,
+        "multiple_choice_responses": multiple_choice_responses,
+        "responses": responses,
+        "themes": filtered_themes,
         "highest_theme_count": highest_theme_count,
         "total_responses": total_responses,
+        "applied_filters": applied_filters,
     }
     return render(request, "show_question.html", context)

--- a/consultation_analyser/consultations/views/responses.py
+++ b/consultation_analyser/consultations/views/responses.py
@@ -4,24 +4,7 @@ from django.shortcuts import render
 from waffle.decorators import waffle_switch
 
 from .. import models
-
-
-def get_applied_filters(request: HttpRequest):
-    return {
-        "keyword": request.GET.get("keyword", ""),
-        "theme": request.GET.get("theme", "All"),
-        "opinion": request.GET.get("opinion", "All"),
-    }
-
-
-def get_filtered_responses(question: models.Question, applied_filters):
-    queryset = models.Answer.objects.filter(question=question, free_text__icontains=applied_filters["keyword"])
-    if applied_filters["theme"] != "All" and applied_filters["theme"] != "No theme":
-        queryset = queryset.filter(theme=applied_filters["theme"])
-    # TO DO: handle answers with "No theme"
-    if applied_filters["opinion"] != "All":
-        queryset = queryset.filter(multiple_choice_responses=applied_filters["opinion"])
-    return queryset
+from .filters import get_applied_filters, get_filtered_responses
 
 
 @waffle_switch("CONSULTATION_PROCESSING")
@@ -45,7 +28,7 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
         "responses": paginated_responses,
         "total_responses": total_responses,
         "applied_filters": applied_filters,
-        "themes_for_question": themes_for_question,
+        "themes": themes_for_question,
         "pagination": current_page,
     }
 

--- a/tests/integration/test_question_pages.py
+++ b/tests/integration/test_question_pages.py
@@ -29,9 +29,17 @@ def test_get_question_summary_page(django_app):
     answer = question.answer_set.first()
     assert answer.theme.summary in page_content
 
+    for option in question.multiple_choice_options:
+        assert option in page_content
+
     for keyword in answer.theme.keywords:
         assert keyword in page_content
 
     assert re.search(r"Yes\s+50%", question_page.html.text)
     assert re.search(r"No\s+25%", question_page.html.text)
     assert re.search(r"Maybe\s+25%", question_page.html.text)
+
+    filtered_page = django_app.get(f"{question_summary_url}?opinion=Yes")
+    assert re.search(r"Yes\s+100%", filtered_page.html.text)
+    assert re.search(r"No\s+0%", filtered_page.html.text)
+    assert re.search(r"Maybe\s+0%", filtered_page.html.text)

--- a/tests/integration/test_responses_pages.py
+++ b/tests/integration/test_responses_pages.py
@@ -29,7 +29,7 @@ def test_get_question_responses_page(django_app):
     answer_loop_range = min(4, len(answers))
     for i in range(answer_loop_range):
         assert f"{answers[i].free_text}" in page_content
-        assert f"{answers[i].multiple_choice_responses}" in page_content
+        assert f"{answers[i].multiple_choice_responses[0]}" in page_content
         if answers[i].free_text:
             assert f"{answers[i].theme.label}" in page_content
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -37,14 +37,3 @@ def test_multiple_choice_response_count():
 
     for answer in answers:
         factories.AnswerFactory(question=question, multiple_choice_responses=answer)
-
-    response_counts = question.multiple_choice_response_counts()
-
-    assert response_counts[0].count == 2
-    assert response_counts[0].percent == 40.0
-
-    assert response_counts[1].count == 2
-    assert response_counts[1].percent == 40.0
-
-    assert response_counts[2].count == 1
-    assert response_counts[2].percent == 20.0


### PR DESCRIPTION
## Context

This PR add filters to the question summary page.


## Changes proposed in this pull request

* Filters are added to the side panel:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/1634605/4c3c9c0f-70c3-4553-8618-b41f9240fe43)

* A couple of small fixes so people can use the existing filters on the response explorer

* The filters functions have been move to a separate `filters.py` file

* Updating the integration tests


## Guidance to review

Go to a question summary page and check both filters work, and that all data on the page is updated accordingly.


## Link to JIRA ticket

https://technologyprogramme.atlassian.net/browse/CON-84?atlOrigin=eyJpIjoiYzQ4ZjhjMGU4MzM5NGEwNzkzMTJmYjkwN2IzYjQzMDkiLCJwIjoiaiJ9
