### PR TITLE
Force at least one dummy answer to be an outlier.

### DIFF
--- a/consultation_analyser/consultations/dummy_data.py
+++ b/consultation_analyser/consultations/dummy_data.py
@@ -45,9 +45,14 @@ class DummyConsultation:
                 # Set themes per question, multiple answers with the same theme
                 for q in questions:
                     themes = [ThemeFactory() for _ in range(2, 6)]
+                    themes.append(ThemeFactory(is_outlier=True))  # include an outlier
                     for a in _answers:
                         random_theme = random.choice(themes)
                         a.theme = random_theme
                         a.save()
+                # Force at least one answer to be an outlier
+                a = random.choice(_answers)
+                a.theme = themes[-1]
+
             else:
                 _answers = [AnswerFactory(question=q, consultation_response=response, theme=None) for q in questions]

--- a/consultation_analyser/factories.py
+++ b/consultation_analyser/factories.py
@@ -12,11 +12,14 @@ faker = _faker.Faker()
 default_multiple_choice_options = ["Yes", "No", "Not sure"]
 
 
-def generate_dummy_topic_label():
+def generate_dummy_topic_label(is_outlier=False):
     dummy_sentence = faker.sentence()
     words = dummy_sentence.lower().strip(".")
     words_joined = words.replace(" ", "_")
-    topic_number = random.randint(-1, 3)
+    if is_outlier:
+        topic_number = -1
+    else:
+        topic_number = random.randint(0, 3)
     output = f"{topic_number}_{words_joined}"
     return output
 
@@ -113,6 +116,9 @@ class ThemeFactory(factory.django.DjangoModelFactory):
 
     label = factory.LazyAttribute(lambda _o: generate_dummy_topic_label())
     summary = faker.sentence()
+
+    class Params:
+        is_outlier = factory.Trait(label=factory.LazyAttribute(lambda _o: generate_dummy_topic_label(is_outlier=True)))
 
 
 class AnswerFactory(factory.django.DjangoModelFactory):

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -25,3 +25,10 @@ def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"should only be run in development"):
             DummyConsultation()
+
+
+@pytest.mark.django_db
+def test_consultation_contains_outliers():
+    DummyConsultation()
+    qs = Answer.objects.filter(theme__is_outlier=True)
+    assert qs.exists()


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Force outliers to exist when generating dummy data to help with testing.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
When generating themes (factories), have the explicit option of generating an outlier.

When generating dummy data: `poetry run python manage.py generate_dummy_data` - this now explicitly has at least one answer that is an outlier.


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Generate dummy data: `poetry run python manage.py generate_dummy_data` - does this data contain at least one answer which is an outlier?

To view the data: `poetry run python manage.py shell` to access the Django shell. Then run whatever code you like e.g. 

```
from consultation_analyser.consultations.models import Answer
Answer.objects.all().values_list('theme_is_outlier')
```

Or just convince yourself that the test works!



## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A - quick fix to unblock frontend work.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo