### PR TITLE
Just generate a random sentence for the summary.

### DIFF
--- a/consultation_analyser/factories.py
+++ b/consultation_analyser/factories.py
@@ -111,9 +111,8 @@ class ThemeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Theme
 
-    # TODO - may need to be changed once ML pipeline is in
     label = factory.LazyAttribute(lambda _o: generate_dummy_topic_label())
-    summary = f"Summary: {label}"
+    summary = faker.sentence()
 
 
 class AnswerFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

For the dummy data, just generate a random sentence for the theme summary. More sensible than:


![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/4532a568-ecc5-467b-9631-4bc5d38617fe)


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Generate a random sentence for the summary for a theme.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Generate dummy data - check that the summaries in the themes are random sentences.


## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A - quick bugfix.

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo