### PR TITLE
Fix masthead width on Windows

### DIFF
--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -35,6 +35,9 @@ $iai-colour-pink: #C50878;
 
 /* HOMEPAGE */
 
+.x-govuk-masthead {
+    width: 100%;
+}
 .x-govuk-masthead--pink {
     background-color: $iai-colour-pink;
 }

--- a/prototype/app/assets/sass/application.scss
+++ b/prototype/app/assets/sass/application.scss
@@ -17,6 +17,9 @@ $iai-colour-pink: #C50978;
 }
 
 /* HOMEPAGE */
+.x-govuk-masthead {
+  width: 100%;
+}
 .x-govuk-masthead--pink {
   background-color: $iai-colour-pink;
 }


### PR DESCRIPTION
## Context

This is a fix for the homepage masthead component not filling the screen on Windows. I haven't quite replicated the exact problem, but there's a high chance this will fix it anyway!

## Guidance to review

Just check the pink banner on the homepage still looks okay. Once deployed we can then double-check it appears okay on Guy's Windows laptop.