### PR TITLE
Make dependabot weekly for Python.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       pip-updates:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,9 @@ updates:
       interval: "weekly"
     groups:
       pip-updates:
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -17,8 +18,9 @@ updates:
       interval: "weekly"
     groups:
       npm-updates:
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/prototype"
@@ -26,8 +28,9 @@ updates:
       interval: "weekly"
     groups:
       prototype-updates:
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -35,5 +38,6 @@ updates:
       interval: "weekly"
     groups:
       actions-updates:
-        patterns:
-          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Make dependabot updates for Python consistent with others, and weekly.
Make the weekly updates for minor/patch updates (as per Slack discussion). We will get major updates separately - 1 PR per update.
https://i-dot-ai.slack.com/archives/C06LTGX7GGK/p1714483132352949

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Get dependabot updates grouped, weekly.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does it look sensible?

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo