### PR TITLE
Add backlinks and tidy up headings

### DIFF
--- a/consultation_analyser/consultations/jinja2/base.html
+++ b/consultation_analyser/consultations/jinja2/base.html
@@ -47,6 +47,9 @@
       "html": 'This is a new service – your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/GESFSF/">feedback</a> will help us to improve it.'
     }) }}
 
+    {% block pre_main %}
+    {% endblock %}
+
     <main class="govuk-main-wrapper" id="main-content" role="main">
       {% include "messages.html" %}
       {% block content %}

--- a/consultation_analyser/consultations/jinja2/magic_link/link_sent.html
+++ b/consultation_analyser/consultations/jinja2/magic_link/link_sent.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Sign in — confirmation</h1>
+      <h1 class="govuk-heading-l">Sign in — link sent</h1>
       <p class="govuk-body">If you have previously registered, please check your emails for a link to sign in</p>
     </div>
   </div>

--- a/consultation_analyser/consultations/jinja2/magic_link/logmein.html
+++ b/consultation_analyser/consultations/jinja2/magic_link/logmein.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 
-{% set page_title = "Sign in" %}
+{% set page_title = "Sign in - confirmation" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Sign in — confirmation</h1>
       <form method="POST" action="{{ link.get_absolute_url() }}">
           {{ csrf_input }}
           <input type="submit" value="Sign in" class="govuk-button" data-module="govuk-button" />

--- a/consultation_analyser/consultations/jinja2/show_question.html
+++ b/consultation_analyser/consultations/jinja2/show_question.html
@@ -1,7 +1,15 @@
 {% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
-{% set page_title = "Question summary - dummy page" %}
+{% set page_title = "Question summary" %}
+
+{% block pre_main %}
+  {{ govukBackLink({
+    "text": "Back to all questions",
+    "href": "/consultations/" + consultation_slug
+  }) }}
+{% endblock %}
 
 {% block content %}
 

--- a/consultation_analyser/consultations/jinja2/show_responses.html
+++ b/consultation_analyser/consultations/jinja2/show_responses.html
@@ -1,9 +1,15 @@
 {% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
-{%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
 
-{% set page_title = "Responses - dummy page" %}
+{% set page_title = "Response explorer" %}
 
+{% block pre_main %}
+  {{ govukBackLink({
+    "text": "Back to all questions",
+    "href": "/consultations/" + consultation_slug
+  }) }}
+{% endblock %}
 
 {% block content %}
 

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -26,6 +26,7 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
     highest_theme_count = filtered_themes.aggregate(Max("answer_count"))["answer_count__max"]
 
     context = {
+        "consultation_slug": consultation_slug,
         "question": question,
         "multiple_choice_responses": multiple_choice_responses,
         "responses": responses,

--- a/consultation_analyser/consultations/views/responses.py
+++ b/consultation_analyser/consultations/views/responses.py
@@ -24,6 +24,7 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
     paginated_responses = current_page.object_list
 
     context = {
+        "consultation_slug": consultation_slug,
         "question": question,
         "responses": paginated_responses,
         "total_responses": total_responses,


### PR DESCRIPTION
## Context

This is a general tidy-up of headings and navigation

## Changes proposed in this pull request

* Add backlinks to question-summary and response-explorer pages
* Remove "dummy page" text
* Add a H1 to the landing page after following the magic link

## Guidance to review

* Check the backlinks
* Checking page headings look okay

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/browse/CON-151?atlOrigin=eyJpIjoiZGI1NmIwMWZiOGIxNGZhNGI3NTZhNGFmYjM0OGJhNzEiLCJwIjoiaiJ9
