### PR TITLE
Feature/basic user management via support

### DIFF
--- a/consultation_analyser/authentication/admin.py
+++ b/consultation_analyser/authentication/admin.py
@@ -1,8 +1,5 @@
 from django.contrib import admin
 from django.contrib.auth.models import Group
 
-from .models import User
-
 # leave this out until we know what we’re doing with Groups etc
 admin.site.unregister(Group)
-admin.site.register(User)

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -29,6 +29,12 @@ def app_config(request: HttpRequest):
                 {
                     "href": "/support/consultations/",
                     "text": "Consultations",
+                    "active": request.path.startswith("/support/consultations"),
+                },
+                {
+                    "href": "/support/users/",
+                    "text": "Users",
+                    "active": request.path.startswith("/support/users"),
                 },
                 {
                     "href": "/support/sign-out/",

--- a/consultation_analyser/support_console/forms/edit_user_form.py
+++ b/consultation_analyser/support_console/forms/edit_user_form.py
@@ -1,5 +1,5 @@
 from crispy_forms_gds.helper import FormHelper
-from crispy_forms_gds.layout import Field, Submit, Layout
+from crispy_forms_gds.layout import Field, Layout, Submit
 from django import forms
 
 from consultation_analyser.authentication.models import User
@@ -11,10 +11,21 @@ class EditUserForm(forms.Form):
         required=False,
     )
 
+    user_id = forms.IntegerField()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        user_id = cleaned_data.get("user_id")
+
+        if (self.current_user.id == user_id) and cleaned_data["is_staff"] is not True:
+            raise forms.ValidationError("You cannot remove admin privileges from your own user")
+
     def __init__(self, *args, **kwargs):
+        self.current_user = kwargs.pop("current_user", None)
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.layout = Layout(
+            Field("user_id", type="hidden"),
             Field.checkboxes("is_staff"),
             Submit("submit", "Update user"),
         )

--- a/consultation_analyser/support_console/forms/edit_user_form.py
+++ b/consultation_analyser/support_console/forms/edit_user_form.py
@@ -1,0 +1,20 @@
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Field, Submit, Layout
+from django import forms
+
+from consultation_analyser.authentication.models import User
+
+
+class EditUserForm(forms.Form):
+    is_staff = forms.BooleanField(
+        label="Can access support console",
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Field.checkboxes("is_staff"),
+            Submit("submit", "Update user"),
+        )

--- a/consultation_analyser/support_console/forms/new_user_form.py
+++ b/consultation_analyser/support_console/forms/new_user_form.py
@@ -1,0 +1,26 @@
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Button, Layout
+from django import forms
+from django.core.exceptions import ValidationError
+
+from consultation_analyser.authentication.models import User
+
+
+def validate_unique_email(value):
+    if User.objects.filter(email=value).exists():
+        raise ValidationError("A user already exists with this email address")
+
+
+class NewUserForm(forms.Form):
+    email = forms.EmailField(
+        label="Email address",
+        help_text="Enter the email of the user to invite",
+        error_messages={"required": "Your email address is required", "invalid": "Enter a valid email address"},
+        validators=[validate_unique_email],
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.attrs = {"novalidate": ""}
+        self.helper.layout = Layout("email", Button("submit", "Continue"))

--- a/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
@@ -1,28 +1,37 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
-{% set page_title = "All consultations" %}
+{% set page_title = "Consultations" %}
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
-  <form method="post" novalidate>{{ csrf_input }}
-    <ul class="govuk-list">
-      {% for consultation in consultations %}
-        <li>
-          <a href="{{ url('support_consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-body govuk-link govuk-link--no-visited-state">
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Consultation name</th>
+        <th scope="col" class="govuk-table__header">Created at</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for consultation in consultations %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <a href="{{ url('support_consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-link--no-visited-state">
             {{ consultation.name }}
           </a>
-        </li>
-      {% endfor %}
-    </ul>
-
+        </td>
+        <td class="govuk-table__cell">
+          {{ consultation.created_at }}
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+  <form method="post" novalidate>{{ csrf_input }}
     {% if development_env %}
       {{ govukButton({
         'text': "Generate dummy consultation",
         'name': "generate_dummy_consultation"
       }) }}
     {% endif %}
-
   </form>
-
 {% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/all-users.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-users.html
@@ -15,6 +15,7 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Email</th>
+        <th scope="col" class="govuk-table__header">Created at</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -22,6 +23,9 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <a class="govuk-link" href="/support/users/{{ user.id }}">{{ user.email }}</a>
+        </td>
+        <td class="govuk-table__cell">
+          {{ user.created_at }}
         </td>
       </tr>
     {% endfor %}

--- a/consultation_analyser/support_console/jinja2/support_console/all-users.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-users.html
@@ -21,7 +21,7 @@
     {% for user in users %}
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          {{ user.email }}
+          <a class="govuk-link" href="/support/users/{{ user.id }}">{{ user.email }}</a>
         </td>
       </tr>
     {% endfor %}

--- a/consultation_analyser/support_console/jinja2/support_console/all-users.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-users.html
@@ -3,8 +3,14 @@
 
 {% set page_title = "Users" %}
 
+
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
+
+  <a href="/support/users/new" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+    Add a new user
+  </a>
+
   <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/consultation_analyser/support_console/jinja2/support_console/all-users.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-users.html
@@ -16,6 +16,7 @@
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">Email</th>
         <th scope="col" class="govuk-table__header">Created at</th>
+        <th scope="col" class="govuk-table__header">Can access support console</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -26,6 +27,13 @@
         </td>
         <td class="govuk-table__cell">
           {{ user.created_at }}
+        </td>
+        <td class="govuk-table__cell">
+          {% if user.is_staff %}
+            Yes
+          {% else %}
+            No
+          {% endif %}
         </td>
       </tr>
     {% endfor %}

--- a/consultation_analyser/support_console/jinja2/support_console/all-users.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-users.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = "Users" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Email</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+    {% for user in users %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          {{ user.email }}
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultation.html
@@ -1,24 +1,24 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
-{% set page_title = "Consultation" %}
+{% set page_title = consultation.name %}
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <div>
+
+    <a href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-body govuk-link--no-visited-state">
+      View on frontend
+    </a>
+  </div>
+
+  <br />
+
   <form method="post" novalidate>{{ csrf_input }}
-    <div>
-      <a href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-body govuk-link govuk-link--no-visited-state">
-        {{ consultation.name }}
-      </a>
-    </div>
-
-    <br>
-
     {{ govukButton({
       'text': "Generate themes",
       'name': "generate_themes"
     }) }}
-
   </form>
 
 {% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/home.html
+++ b/consultation_analyser/support_console/jinja2/support_console/home.html
@@ -1,1 +1,0 @@
-{% extends "base.html" %}

--- a/consultation_analyser/support_console/jinja2/support_console/new-user.html
+++ b/consultation_analyser/support_console/jinja2/support_console/new-user.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% set page_title = "Add a user" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Add a user</h1>
+      {{ render_form(form, request) }}
+    </div>
+  </div>
+{% endblock %}

--- a/consultation_analyser/support_console/jinja2/support_console/user.html
+++ b/consultation_analyser/support_console/jinja2/support_console/user.html
@@ -18,6 +18,12 @@
         </tbody>
       </table>
 
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          {{ render_form(form, request) }}
+        </div>
+      </div>
+
       <h2 class="govuk-heading-m">Consultations</h2>
 
       {% if consultations %}

--- a/consultation_analyser/support_console/jinja2/support_console/user.html
+++ b/consultation_analyser/support_console/jinja2/support_console/user.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% set page_title = "User details" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">{{ user.email }}</h1>
+
+      <table class="govuk-table">
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Created at</th>
+            <td class="govuk-table__cell">
+              {{ user.created_at }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 class="govuk-heading-m">Consultations</h2>
+
+      {% if consultations %}
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Consultation name</th>
+              <th scope="col" class="govuk-table__header">Created at</th>
+              <th scope="col" class="govuk-table__header">Links</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            {% for consultation in consultations %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  {{ consultation.name }}
+                </td>
+                <td class="govuk-table__cell">
+                  {{ consultation.created_at }}
+                </td>
+                <td class="govuk-table__cell">
+                  <a class="govuk-link" href="/support/consultations/{{ consultation.slug }}">View in support</a><br />
+                  <a class="govuk-link" href="/consultations/{{ consultation.slug }}">View on frontend</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="govuk-body">This user is not associated with any consultations</p>
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}
+

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import consultations, pages
+from .views import consultations, pages, users
 
 urlpatterns = [
     path("", pages.support_home),
     path("sign-out/", pages.sign_out),
+    path("users/", users.index),
     path("consultations/", consultations.index),
     path("consultations/<str:consultation_slug>/", consultations.show, name="support_consultation"),
 ]

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("sign-out/", pages.sign_out),
     path("users/", users.index),
     path("users/new", users.new),
+    path("users/<int:user_id>", users.show),
     path("consultations/", consultations.index),
     path("consultations/<str:consultation_slug>/", consultations.show, name="support_consultation"),
 ]

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path("", pages.support_home),
     path("sign-out/", pages.sign_out),
     path("users/", users.index),
+    path("users/new", users.new),
     path("consultations/", consultations.index),
     path("consultations/<str:consultation_slug>/", consultations.show, name="support_consultation"),
 ]

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 from .views import consultations, pages, users
 
 urlpatterns = [
-    path("", pages.support_home),
+    path("", consultations.index),
     path("sign-out/", pages.sign_out),
     path("users/", users.index),
     path("users/new", users.new),

--- a/consultation_analyser/support_console/views/pages.py
+++ b/consultation_analyser/support_console/views/pages.py
@@ -5,11 +5,6 @@ from django.shortcuts import redirect, render
 
 
 @staff_member_required
-def support_home(request: HttpRequest):
-    return render(request, "support_console/home.html")
-
-
-@staff_member_required
 def sign_out(request: HttpRequest):
     logout(request)
     return redirect("/")

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -5,8 +5,8 @@ from django.shortcuts import get_object_or_404, redirect, render
 
 from consultation_analyser.authentication.models import User
 
-from ..forms.new_user_form import NewUserForm
 from ..forms.edit_user_form import EditUserForm
+from ..forms.new_user_form import NewUserForm
 
 
 @staff_member_required
@@ -36,9 +36,9 @@ def show(request: HttpRequest, user_id: int):
     consultations = user.consultation_set.all()
 
     if not request.POST:
-        form = EditUserForm({"is_staff": user.is_staff})
+        form = EditUserForm({"user_id": user_id, "is_staff": user.is_staff})
     else:
-        form = EditUserForm(request.POST)
+        form = EditUserForm(request.POST, current_user=request.user)
         if form.is_valid():
             is_staff = form.cleaned_data["is_staff"]
             user.is_staff = is_staff

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.http import HttpRequest
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect, render, get_object_or_404
 
 from consultation_analyser.authentication.models import User
 
@@ -24,3 +24,11 @@ def new(request: HttpRequest):
             return redirect("/support/users")
 
     return render(request, "support_console/new-user.html", {"form": form})
+
+
+
+def show(request: HttpRequest, user_id: int):
+    user = get_object_or_404(User, pk=user_id)
+    consultations = user.consultation_set.all()
+    return render(request, "support_console/user.html", {"user": user, "consultations": consultations})
+

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -1,8 +1,26 @@
-from django.shortcuts import render
+from django.contrib import messages
 from django.http import HttpRequest
+from django.shortcuts import redirect, render
 
 from consultation_analyser.authentication.models import User
 
+from ..forms.new_user_form import NewUserForm
+
+
 def index(request: HttpRequest):
-    users = User.objects.all()
-    return render(request, "support_console/all-users.html", { "users": users })
+    users = User.objects.all().order_by("-created_at")
+    return render(request, "support_console/all-users.html", {"users": users})
+
+
+def new(request: HttpRequest):
+    if not request.POST:
+        form = NewUserForm()
+    else:
+        form = NewUserForm(request.POST)
+        if form.is_valid():
+            email = form.cleaned_data["email"]
+            User.objects.create_user(email=email)
+            messages.success(request, "User added")
+            return redirect("/support/users")
+
+    return render(request, "support_console/new-user.html", {"form": form})

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -1,0 +1,8 @@
+from django.shortcuts import render
+from django.http import HttpRequest
+
+from consultation_analyser.authentication.models import User
+
+def index(request: HttpRequest):
+    users = User.objects.all()
+    return render(request, "support_console/all-users.html", { "users": users })

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from consultation_analyser.authentication.models import User
 
 from ..forms.new_user_form import NewUserForm
+from ..forms.edit_user_form import EditUserForm
 
 
 @staff_member_required
@@ -33,4 +34,16 @@ def new(request: HttpRequest):
 def show(request: HttpRequest, user_id: int):
     user = get_object_or_404(User, pk=user_id)
     consultations = user.consultation_set.all()
-    return render(request, "support_console/user.html", {"user": user, "consultations": consultations})
+
+    if not request.POST:
+        form = EditUserForm({"is_staff": user.is_staff})
+    else:
+        form = EditUserForm(request.POST)
+        if form.is_valid():
+            is_staff = form.cleaned_data["is_staff"]
+            user.is_staff = is_staff
+            user.save()
+            messages.success(request, "User updated")
+            return redirect(request.path_info)
+
+    return render(request, "support_console/user.html", {"user": user, "consultations": consultations, "form": form})

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -1,17 +1,20 @@
 from django.contrib import messages
 from django.http import HttpRequest
 from django.shortcuts import redirect, render, get_object_or_404
+from django.contrib.admin.views.decorators import staff_member_required
 
 from consultation_analyser.authentication.models import User
 
 from ..forms.new_user_form import NewUserForm
 
 
+@staff_member_required
 def index(request: HttpRequest):
     users = User.objects.all().order_by("-created_at")
     return render(request, "support_console/all-users.html", {"users": users})
 
 
+@staff_member_required
 def new(request: HttpRequest):
     if not request.POST:
         form = NewUserForm()
@@ -26,9 +29,8 @@ def new(request: HttpRequest):
     return render(request, "support_console/new-user.html", {"form": form})
 
 
-
+@staff_member_required
 def show(request: HttpRequest, user_id: int):
     user = get_object_or_404(User, pk=user_id)
     consultations = user.consultation_set.all()
     return render(request, "support_console/user.html", {"user": user, "consultations": consultations})
-

--- a/consultation_analyser/support_console/views/users.py
+++ b/consultation_analyser/support_console/views/users.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
-from django.http import HttpRequest
-from django.shortcuts import redirect, render, get_object_or_404
 from django.contrib.admin.views.decorators import staff_member_required
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404, redirect, render
 
 from consultation_analyser.authentication.models import User
 

--- a/tests/integration/test_managing_users_via_support.py
+++ b/tests/integration/test_managing_users_via_support.py
@@ -32,3 +32,11 @@ def test_managing_users_via_support(django_app):
 
     assert "User updated" in updated_user_page
     assert user_page.form["is_staff"].checked is True
+
+    users_page = django_app.get("/support/users/")
+    user_page = users_page.click("email@example.com")
+
+    user_page.form["is_staff"] = False
+    failed_user_page = user_page.form.submit()
+
+    assert "You cannot remove admin privileges from your own user" in failed_user_page

--- a/tests/integration/test_managing_users_via_support.py
+++ b/tests/integration/test_managing_users_via_support.py
@@ -7,7 +7,7 @@ from tests.helpers import sign_in
 
 @pytest.mark.django_db
 @override_switch("FRONTEND_USER_LOGIN", True)
-def test_managin_users_via_support(django_app):
+def test_managing_users_via_support(django_app):
     # given I am an admin user
     user = UserFactory(email="email@example.com", password="admin", is_staff=True)  # pragma: allowlist secret
     sign_in(django_app, user.email)
@@ -23,3 +23,12 @@ def test_managin_users_via_support(django_app):
 
     assert "User added" in users_page
     assert "a-new-user@example.com" in users_page
+
+    user_page = users_page.click("a-new-user@example.com")
+    assert user_page.form["is_staff"].checked is not True
+
+    user_page.form["is_staff"] = True
+    updated_user_page = user_page.form.submit().follow()
+
+    assert "User updated" in updated_user_page
+    assert user_page.form["is_staff"].checked is True

--- a/tests/integration/test_managing_users_via_support.py
+++ b/tests/integration/test_managing_users_via_support.py
@@ -1,0 +1,25 @@
+import pytest
+from waffle.testutils import override_switch
+
+from consultation_analyser.factories import UserFactory
+from tests.helpers import sign_in
+
+
+@pytest.mark.django_db
+@override_switch("FRONTEND_USER_LOGIN", True)
+def test_managin_users_via_support(django_app):
+    # given I am an admin user
+    user = UserFactory(email="email@example.com", password="admin", is_staff=True)  # pragma: allowlist secret
+    sign_in(django_app, user.email)
+
+    users_page = django_app.get("/support/users/")
+
+    assert "email@example.com" in users_page
+
+    new_user_page = users_page.click("Add a new user")
+
+    new_user_page.form["email"] = "a-new-user@example.com"
+    users_page = new_user_page.form.submit().follow().follow()
+
+    assert "User added" in users_page
+    assert "a-new-user@example.com" in users_page

--- a/tests/integration/test_support_console_pages.py
+++ b/tests/integration/test_support_console_pages.py
@@ -34,7 +34,7 @@ def test_generating_dummy_data(django_app):
     login_page.form["username"] = "email@example.com"
     login_page.form["password"] = "admin"  # pragma: allowlist secret
     consultations_page = login_page.form.submit().follow()
-    assert "All consultations" in consultations_page
+    assert "Consultations" in consultations_page
 
     # Check dummy data button does generate a new consultation
     initial_count = Consultation.objects.all().count()


### PR DESCRIPTION
## builds on #165 

## Context

We're going to need to add users, associate them with consultations etc.

This is quite a bit of code but none of it is complicated.

This PR adds user creation via support and allows us to see which consultations a user is associated with.

Next we can add a way to update a user's consultations.

## Changes proposed in this pull request

- Support CR (but not UD) on users via `/support/users`
- Clean up the `/support/consultations` to be similar

### Consultations page

<img width="990" alt="Screenshot 2024-05-02 at 19 35 46" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/694db844-dcda-490b-95a0-f1c0ef3d87f8">

### Users page

<img width="994" alt="Screenshot 2024-05-02 at 19 35 51" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/b783b977-602b-4a55-9f56-2735b9e48b77">

### Add user screen

<img width="990" alt="Screenshot 2024-05-02 at 19 35 55" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/4b4b64b2-e42d-4bee-9434-8990595a654e">

## Guidance to review

Review once #165 is in.

I know that at this stage this is recreating functionality from the django admin, but I feel very confident things will get complicated enough soon enough that setting this up for ourselves is worthwhile at this stage.

There's only one, quite scanty test, because the flow's not complicated and it's only for us.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo