### PR TITLE
Don't update torch - doesn't work on older Macs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Don't update to 2.3 as doesn't work on older Macs
+      - dependency-name: "torch"
+        versions: ["2.3",]
     groups:
       pip-updates:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     ignore:
       # Don't update to 2.3 as doesn't work on older Macs
       - dependency-name: "torch"
-        versions: ["2.3",]
+        versions: ["2.3"]
     groups:
       pip-updates:
         update-types:


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
I think dependabot updates versions whatever you've specified in pyproject.toml. Stop it from updating torch.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Docs for ignore: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore
Have checked that it's not poetry - as running `poetry update` doesn't update the `torch` package.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo