### PR TITLE
Feature/upload consultation

### DIFF
--- a/consultation_analyser/consultations/forms/consultation_upload_form.py
+++ b/consultation_analyser/consultations/forms/consultation_upload_form.py
@@ -1,0 +1,39 @@
+import json
+
+from crispy_forms_gds.helper import FormHelper
+from crispy_forms_gds.layout import Button, Layout
+from django import forms
+from django.core import exceptions as django_exceptions
+from jsonschema import exceptions as jsonschema_exceptions
+from jsonschema import validate
+from jsonschema.validators import Draft202012Validator
+
+from consultation_analyser.consultations.views.schema import SCHEMA_DIR  # refactor this
+
+
+def validate_consultation_json(value):
+    uploaded_json = json.loads(value.read())
+    with open(f"{SCHEMA_DIR}/consultation_with_responses_schema.json") as f:
+        schema = json.loads(f.read())
+
+    try:
+        validate(uploaded_json, schema, format_checker=Draft202012Validator.FORMAT_CHECKER)
+    except jsonschema_exceptions.ValidationError as e:
+        path = [str(el) for el in e.path]
+        raise django_exceptions.ValidationError(f"{' > '.join(path)} > {e.message}")
+    finally:
+        # rewind the file for the next caller
+        value.seek(0)
+
+
+class ConsultationUploadForm(forms.Form):
+    consultation_json = forms.FileField(
+        validators=[validate_consultation_json],
+        label="Upload a consultation file",
+        help_text="Files must be in JSON format to match the <a class='govuk-link' href='/schema'>required schema</a>",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout("consultation_json", Button("submit", "Upload consultation"))

--- a/consultation_analyser/consultations/forms/consultation_upload_form.py
+++ b/consultation_analyser/consultations/forms/consultation_upload_form.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 
 from crispy_forms_gds.helper import FormHelper
 from crispy_forms_gds.layout import Button, Layout
@@ -11,6 +12,26 @@ from jsonschema.validators import Draft202012Validator
 from consultation_analyser.consultations.views.schema import SCHEMA_DIR  # refactor this
 
 
+class DuplicateSectionValidationError(Exception):
+    pass
+
+
+def validate_section_uniqueness(uploaded_json):
+    """
+    Validate that the sections in this JSON all have unique titles.
+    This should run after the JSON schema validator so it can be guaranteed
+    to receive the correct structur
+    """
+    sections = uploaded_json["consultation"]["sections"]
+    section_names = [s["name"] for s in sections]
+
+    counter = Counter(section_names)
+    dupes = set([name for name, count in counter.items() if count > 1])
+
+    if dupes:
+        raise DuplicateSectionValidationError(f"Duplicate sections: {', '.join(dupes)}")
+
+
 def validate_consultation_json(value):
     uploaded_json = json.loads(value.read())
     with open(f"{SCHEMA_DIR}/consultation_with_responses_schema.json") as f:
@@ -18,9 +39,12 @@ def validate_consultation_json(value):
 
     try:
         validate(uploaded_json, schema, format_checker=Draft202012Validator.FORMAT_CHECKER)
+        validate_section_uniqueness(uploaded_json)
     except jsonschema_exceptions.ValidationError as e:
         path = [str(el) for el in e.path]
         raise django_exceptions.ValidationError(f"{' > '.join(path)} > {e.message}")
+    except DuplicateSectionValidationError as e:
+        raise django_exceptions.ValidationError(e)
     finally:
         # rewind the file for the next caller
         value.seek(0)

--- a/consultation_analyser/consultations/jinja2/all-consultations.html
+++ b/consultation_analyser/consultations/jinja2/all-consultations.html
@@ -16,6 +16,9 @@
       {% endfor %}
     {% else %}
       <p class="govuk-body">You do not have any consultations</p>
+      <a href="/consultations/new/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+        Upload a consultation
+      </a>
     {% endif %}
   </ul>
 

--- a/consultation_analyser/consultations/jinja2/consultation-processing.html
+++ b/consultation_analyser/consultations/jinja2/consultation-processing.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% set page_title = "Consultation processing" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Consultation processing</h1>
+
+      <p class="govuk-body">We are processing your consultation. We will be in touch once it’s ready to view.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/consultation_analyser/consultations/jinja2/consultation-uploaded.html
+++ b/consultation_analyser/consultations/jinja2/consultation-uploaded.html
@@ -1,0 +1,20 @@
+{%- from 'govuk_frontend_jinja/components/panel/macro.html' import govukPanel -%}
+{% extends "base.html" %}
+
+{% set page_title = "Consultation uploaded" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    {{ govukPanel({
+      "titleText": "Consultation uploaded",
+      }) }}
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+
+    <p class="govuk-body">The team will be notified that your consultation is ready for processing</p>
+    <p class="govuk-body">We will process it and let you know when the results are ready to view. This should take no more than one working day.</p>
+  </div>
+</div>
+{% endblock %}

--- a/consultation_analyser/consultations/jinja2/consultation-uploaded.html
+++ b/consultation_analyser/consultations/jinja2/consultation-uploaded.html
@@ -13,7 +13,7 @@
 
     <h2 class="govuk-heading-m">What happens next</h2>
 
-    <p class="govuk-body">The team will be notified that your consultation is ready for processing</p>
+    <p class="govuk-body">Please contact the team to let them know your consultation uploaded successfully.</p>
     <p class="govuk-body">We will process it and let you know when the results are ready to view. This should take no more than one working day.</p>
   </div>
 </div>

--- a/consultation_analyser/consultations/jinja2/consultation.html
+++ b/consultation_analyser/consultations/jinja2/consultation.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
 
-{% set page_title = "Consultation" %}
+{% set page_title = consultation.name %}
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>

--- a/consultation_analyser/consultations/jinja2/new-consultation.html
+++ b/consultation_analyser/consultations/jinja2/new-consultation.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% set page_title = "Upload a consultation" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Upload a consultation</h1>
+      {{ render_form(form, request) }}
+    </div>
+  </div>
+{% endblock %}

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -29,6 +29,9 @@ class Consultation(UUIDPrimaryKeyModel, TimeStampedModel):
     slug = models.CharField(null=False, max_length=256)
     users = models.ManyToManyField(User)
 
+    def has_themes(self):
+        return Theme.objects.filter(answer__question__section__consultation=self).exists()
+
     class Meta(UUIDPrimaryKeyModel.Meta, TimeStampedModel.Meta):
         pass
 

--- a/consultation_analyser/consultations/upload_consultation.py
+++ b/consultation_analyser/consultations/upload_consultation.py
@@ -25,6 +25,8 @@ def upload_consultation(file, user):
     consultation.save()
     consultation.users.set([user])
 
+    question_ids_map = {}
+
     for section_attrs in sections:
         section_attrs["consultation_id"] = consultation.id
         questions = section_attrs.pop("questions")
@@ -32,10 +34,12 @@ def upload_consultation(file, user):
         section = Section(**section_attrs)
         section.save()
         for question_attrs in questions:
+            supplied_id = question_attrs.pop("id")
             question_attrs["slug"] = slugify(question_attrs["text"])
             question_attrs["section_id"] = section.id
             question = Question(**question_attrs)
             question.save()
+            question_ids_map[supplied_id] = question.id
 
     for response_attrs in responses:
         answers = response_attrs.pop("answers")
@@ -44,6 +48,8 @@ def upload_consultation(file, user):
         response.save()
         for answer_attrs in answers:
             answer_attrs["consultation_response_id"] = response.id
+            question_id = answer_attrs.pop("question_id")
+            answer_attrs["question_id"] = question_ids_map[question_id]
             answer = Answer(**answer_attrs)
             answer.save()
 

--- a/consultation_analyser/consultations/upload_consultation.py
+++ b/consultation_analyser/consultations/upload_consultation.py
@@ -1,0 +1,50 @@
+import json
+
+from django.utils.text import slugify
+
+from consultation_analyser.consultations.public_schema import ConsultationWithResponses
+
+from .models import Answer, Consultation, ConsultationResponse, Question, Section
+
+
+def upload_consultation(file, user):
+    uploaded_json = file.read()
+
+    consultation_data = json.loads(uploaded_json)
+    consultation_with_responses = ConsultationWithResponses(**consultation_data)
+
+    # convert to JSON and back to get a big dict
+    attrs = json.loads(consultation_with_responses.json())
+
+    responses = attrs["consultation_responses"]
+    consultation_attrs = attrs["consultation"]
+    sections = consultation_attrs.pop("sections")
+
+    consultation_attrs["slug"] = slugify(consultation_attrs["name"])
+    consultation = Consultation(**consultation_attrs)
+    consultation.save()
+    consultation.users.set([user])
+
+    for section_attrs in sections:
+        section_attrs["consultation_id"] = consultation.id
+        questions = section_attrs.pop("questions")
+        section_attrs["slug"] = slugify(section_attrs["name"])
+        section = Section(**section_attrs)
+        section.save()
+        for question_attrs in questions:
+            question_attrs["slug"] = slugify(question_attrs["text"])
+            question_attrs["section_id"] = section.id
+            question = Question(**question_attrs)
+            question.save()
+
+    for response_attrs in responses:
+        answers = response_attrs.pop("answers")
+        response_attrs["consultation_id"] = consultation.id
+        response = ConsultationResponse(**response_attrs)
+        response.save()
+        for answer_attrs in answers:
+            answer_attrs["consultation_response_id"] = response.id
+            answer = Answer(**answer_attrs)
+            answer.save()
+
+    return consultation

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -11,7 +11,8 @@ urlpatterns = [
     path("get-involved/", pages.get_involved),
     path("privacy/", pages.privacy),
     path("consultations/", consultations.index, name="consultations"),
-    path("consultations/new", consultations.new, name="new_consultation"),
+    path("consultations/new/", consultations.new, name="new_consultation"),
+    path("consultations/processing/", consultations.processing, name="consultation_processing"),
     path("consultations/<str:consultation_slug>/", consultations.show, name="consultation"),
     path("schema/<str:schema_name>.json", schema.raw_schema),
     path(

--- a/consultation_analyser/consultations/urls.py
+++ b/consultation_analyser/consultations/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path("get-involved/", pages.get_involved),
     path("privacy/", pages.privacy),
     path("consultations/", consultations.index, name="consultations"),
+    path("consultations/new", consultations.new, name="new_consultation"),
     path("consultations/<str:consultation_slug>/", consultations.show, name="consultation"),
     path("schema/<str:schema_name>.json", schema.raw_schema),
     path(

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -1,7 +1,8 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, render
+
 from consultation_analyser.consultations.upload_consultation import upload_consultation
 
 from .. import models
@@ -34,7 +35,7 @@ def new(request: HttpRequest):
     else:
         form = ConsultationUploadForm(request.POST, request.FILES)
         if form.is_valid():
-            consultation = upload_consultation(request.FILES["consultation_json"], request.user)
-            return redirect(f"/consultations/{consultation.slug}/")
+            upload_consultation(request.FILES["consultation_json"], request.user)
+            return render(request, "consultation-uploaded.html", {})
 
     return render(request, "new-consultation.html", {"form": form})

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from consultation_analyser.consultations.upload_consultation import upload_consultation
 
 from .. import models
 from ..forms.consultation_upload_form import ConsultationUploadForm
@@ -30,6 +31,7 @@ def new(request: HttpRequest):
     else:
         form = ConsultationUploadForm(request.POST, request.FILES)
         if form.is_valid():
+            consultation = upload_consultation(request.FILES["consultation_json"], request.user)
             return redirect(f"/consultations/{consultation.slug}/")
 
     return render(request, "new-consultation.html", {"form": form})

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -29,6 +29,11 @@ def show(request: HttpRequest, consultation_slug: str) -> HttpResponse:
 
 
 @login_required
+def processing(request: HttpRequest) -> HttpResponse:
+    return render(request, "consultation-processing.html", {})
+
+
+@login_required
 def new(request: HttpRequest):
     if not request.POST:
         form = ConsultationUploadForm()

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -19,8 +19,11 @@ def index(request: HttpRequest) -> HttpResponse:
 @user_can_see_consultation
 @login_required
 def show(request: HttpRequest, consultation_slug: str) -> HttpResponse:
+    consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
     questions = models.Question.objects.filter(section__consultation__slug=consultation_slug)
-    context = {"questions": questions}
+
+    context = {"questions": questions, "consultation": consultation}
+
     return render(request, "consultation.html", context)
 
 

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -1,8 +1,10 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, redirect, render
 
 from .. import models
+from ..forms.consultation_upload_form import ConsultationUploadForm
 from .decorators import user_can_see_consultation
 
 
@@ -19,3 +21,15 @@ def show(request: HttpRequest, consultation_slug: str) -> HttpResponse:
     questions = models.Question.objects.filter(section__consultation__slug=consultation_slug)
     context = {"questions": questions}
     return render(request, "consultation.html", context)
+
+
+@login_required
+def new(request: HttpRequest):
+    if not request.POST:
+        form = ConsultationUploadForm()
+    else:
+        form = ConsultationUploadForm(request.POST, request.FILES)
+        if form.is_valid():
+            return redirect(f"/consultations/{consultation.slug}/")
+
+    return render(request, "new-consultation.html", {"form": form})

--- a/consultation_analyser/consultations/views/decorators.py
+++ b/consultation_analyser/consultations/views/decorators.py
@@ -7,7 +7,12 @@ def user_can_see_consultation(view_function):
     def decorator(*args, **kwargs):
         request = args[0]
         slug = kwargs.get("consultation_slug")
-        obj = get_object_or_404(models.Consultation.objects.filter(slug=slug, users__in=[request.user]))
+
+        # will kick out users by throwing a 404 if they don't own the consultation
+        consultation = get_object_or_404(models.Consultation.objects.filter(slug=slug, users__in=[request.user]))
+
+        if not consultation.has_themes():
+            return redirect("/consultations/processing/")
 
         return view_function(*args, **kwargs)
 

--- a/consultation_analyser/consultations/views/decorators.py
+++ b/consultation_analyser/consultations/views/decorators.py
@@ -1,4 +1,4 @@
-from django.shortcuts import redirect, get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 
 from .. import models
 

--- a/consultation_analyser/consultations/views/decorators.py
+++ b/consultation_analyser/consultations/views/decorators.py
@@ -1,4 +1,4 @@
-from django.shortcuts import get_object_or_404
+from django.shortcuts import redirect, get_object_or_404
 
 from .. import models
 

--- a/consultation_analyser/pipeline/dummy_pipeline.py
+++ b/consultation_analyser/pipeline/dummy_pipeline.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+from faker import Faker
+from consultation_analyser.consultations import models
+
+
+def save_themes_for_consultation(consultation_id: UUID) -> None:
+    faker = Faker()
+
+    answers = (
+        models.Answer.objects.select_related("question")
+        .filter(question__section__consultation__id=consultation_id, question__has_free_text=True)
+        .all()
+    )
+
+    for answer in answers.all():
+        random_themes = faker.words()
+        for theme in random_themes:
+            answer.save_theme_to_answer(theme, is_outlier=False)

--- a/consultation_analyser/pipeline/dummy_pipeline.py
+++ b/consultation_analyser/pipeline/dummy_pipeline.py
@@ -1,5 +1,7 @@
 from uuid import UUID
+
 from faker import Faker
+
 from consultation_analyser.consultations import models
 
 

--- a/tests/examples/upload.json
+++ b/tests/examples/upload.json
@@ -1,0 +1,61 @@
+{
+  "consultation": {
+    "name": "My consultation",
+    "sections": [
+      {
+        "name": "My section",
+        "questions": [
+          {
+            "id": "11111111-bbbb-48e0-8445-af588c63867e",
+            "text": "Free text Q",
+            "has_free_text": true
+          },
+          {
+            "id": "22222222-bbbb-4a4b-ad2f-bc82b9b6eec7",
+            "text": "Multichoice Q",
+            "has_free_text": true,
+            "multiple_choice_options": [
+              "a",
+              "b",
+              "c"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "consultation_responses": [
+    {
+      "submitted_at": "2018-11-13T20:20:39+00:00",
+      "answers": [
+        {
+          "question_id": "11111111-bbbb-48e0-8445-af588c63867e",
+          "free_text": "Free answer"
+        },
+        {
+          "question_id": "22222222-bbbb-4a4b-ad2f-bc82b9b6eec7",
+          "free_text": "Free answer 2",
+          "multiple_choice": [
+            "b"
+          ]
+        }
+      ]
+    },
+    {
+      "submitted_at": "2018-11-13T20:20:39+00:00",
+      "answers": [
+        {
+          "question_id": "11111111-bbbb-48e0-8445-af588c63867e",
+          "free_text": "Free answer from second resp"
+        },
+        {
+          "question_id": "22222222-bbbb-4a4b-ad2f-bc82b9b6eec7",
+          "free_text": "Free answer 2 from second resp",
+          "multiple_choice": [
+            "a"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/examples/upload.json
+++ b/tests/examples/upload.json
@@ -6,13 +6,13 @@
         "name": "My section",
         "questions": [
           {
-            "id": "11111111-bbbb-48e0-8445-af588c63867e",
-            "text": "Free text Q",
+            "id": "question-1",
+            "text": "Question 1",
             "has_free_text": true
           },
           {
-            "id": "22222222-bbbb-4a4b-ad2f-bc82b9b6eec7",
-            "text": "Multichoice Q",
+            "id": "question-2",
+            "text": "Question 2",
             "has_free_text": true,
             "multiple_choice_options": [
               "a",
@@ -29,12 +29,12 @@
       "submitted_at": "2018-11-13T20:20:39+00:00",
       "answers": [
         {
-          "question_id": "11111111-bbbb-48e0-8445-af588c63867e",
-          "free_text": "Free answer"
+          "question_id": "question-1",
+          "free_text": "Answer to Question 1"
         },
         {
-          "question_id": "22222222-bbbb-4a4b-ad2f-bc82b9b6eec7",
-          "free_text": "Free answer 2",
+          "question_id": "question-2",
+          "free_text": "Answer to Question 2",
           "multiple_choice": [
             "b"
           ]
@@ -45,12 +45,12 @@
       "submitted_at": "2018-11-13T20:20:39+00:00",
       "answers": [
         {
-          "question_id": "11111111-bbbb-48e0-8445-af588c63867e",
-          "free_text": "Free answer from second resp"
+          "question_id": "question-1",
+          "free_text": "Answer to Question 1"
         },
         {
-          "question_id": "22222222-bbbb-4a4b-ad2f-bc82b9b6eec7",
-          "free_text": "Free answer 2 from second resp",
+          "question_id": "question-2",
+          "free_text": "Answer to Question 2",
           "multiple_choice": [
             "a"
           ]

--- a/tests/forms/test_consultation_upload_form.py
+++ b/tests/forms/test_consultation_upload_form.py
@@ -1,0 +1,37 @@
+import json
+
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from consultation_analyser.consultations.forms.consultation_upload_form import ConsultationUploadForm
+from consultation_analyser.consultations.public_schema import Question, Section
+
+
+def test_consultation_upload_form_is_valid_for_example_json():
+    file_path = settings.BASE_DIR / "tests" / "examples" / "upload.json"
+    with open(file_path, "rb") as f:
+        uploaded_file = SimpleUploadedFile(file_path.name, f.read(), content_type="application/json")
+
+    form = ConsultationUploadForm({}, {"consultation_json": uploaded_file})
+
+    assert form.is_valid()
+
+
+def test_consultation_upload_form_is_invalid_with_clashing_section_names():
+    file_path = settings.BASE_DIR / "tests" / "examples" / "upload.json"
+    with open(file_path, "rb") as f:
+        contents = json.loads(f.read())
+        question = Question(id="question-99", text="Why?", has_free_text=True)
+        contents["consultation"]["sections"] += [
+            Section(name="Duplicated section", questions=[question]).model_dump(),
+            Section(name="Duplicated section", questions=[question]).model_dump(),
+        ]
+
+        json_to_upload = json.dumps(contents)
+
+        uploaded_file = SimpleUploadedFile(file_path.name, str.encode(json_to_upload), content_type="application/json")
+
+    form = ConsultationUploadForm({}, {"consultation_json": uploaded_file})
+
+    assert not form.is_valid()
+    assert form.errors["consultation_json"] == ["Duplicate sections: Duplicated section"]

--- a/tests/integration/test_consultation_page.py
+++ b/tests/integration/test_consultation_page.py
@@ -9,7 +9,7 @@ from tests.helpers import sign_in
 @override_switch("FRONTEND_USER_LOGIN", True)
 def test_consultation_page(django_app):
     user = UserFactory()
-    consultation = ConsultationFactory(with_question=True, user=user)
+    consultation = ConsultationFactory(with_themes=True, user=user)
 
     sign_in(django_app, user.email)
 

--- a/tests/integration/test_user_uploads_consultation.py
+++ b/tests/integration/test_user_uploads_consultation.py
@@ -28,7 +28,7 @@ def test_user_uploads_consultation(django_app):
 
     # and when I provide my JSON and submit the form
     upload_page.form["consultation_json"] = Upload("consultation.json", binary_data, "application/json")
-    consultation_page = upload_page.form.submit().follow()
+    success_page = upload_page.form.submit()
 
-    # then I should see my consultation
-    assert "My consultation" in consultation_page
+    # then I should see a success page
+    assert "Consultation uploaded" in success_page

--- a/tests/integration/test_user_uploads_consultation.py
+++ b/tests/integration/test_user_uploads_consultation.py
@@ -1,0 +1,34 @@
+import pytest
+from django.conf import settings
+from django.core import mail
+from waffle.testutils import override_switch
+from webtest import Upload
+
+from consultation_analyser.factories import UserFactory
+from tests.helpers import sign_in
+
+
+@pytest.mark.django_db
+@override_switch("FRONTEND_USER_LOGIN", True)
+def test_user_uploads_consultation(django_app):
+    # given i am a user without a consultation
+    user = UserFactory()
+
+    # when I sign in
+    consultations_page = sign_in(django_app, user.email)
+
+    # and I click the link to upload
+    upload_page = consultations_page.click("Upload a consultation")
+
+    # then I should see an upload page
+    assert "Upload a consultation" in upload_page
+
+    with open(settings.BASE_DIR / "tests" / "examples" / "upload.json", "r") as f:
+        binary_data = str.encode(f.read())
+
+    # and when I provide my JSON and submit the form
+    upload_page.form["consultation_json"] = Upload("consultation.json", binary_data, "application/json")
+    consultation_page = upload_page.form.submit().follow()
+
+    # then I should see my consultation
+    assert "My consultation" in consultation_page

--- a/tests/integration/test_user_uploads_consultation.py
+++ b/tests/integration/test_user_uploads_consultation.py
@@ -5,9 +5,8 @@ from waffle.testutils import override_switch
 from webtest import Upload
 
 from consultation_analyser.factories import UserFactory
-from tests.helpers import sign_in
-
 from consultation_analyser.pipeline.dummy_pipeline import save_themes_for_consultation
+from tests.helpers import sign_in
 
 
 @pytest.mark.django_db

--- a/tests/request/test_support_pages.py
+++ b/tests/request/test_support_pages.py
@@ -15,5 +15,4 @@ def test_no_login_support_pages(client):
     for url in support_urls:
         full_url = f"/support/{url}"
         response = client.get(full_url)
-        print(full_url)
         assert response.status_code == 302  # No access, redirect to admin login

--- a/tests/unit/test_upload_consultation.py
+++ b/tests/unit/test_upload_consultation.py
@@ -1,0 +1,30 @@
+import pytest
+from django.conf import settings
+
+from consultation_analyser.consultations.models import Answer, Question
+from consultation_analyser.consultations.upload_consultation import upload_consultation
+from consultation_analyser.factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_upload_consultation():
+    file = open(settings.BASE_DIR / "tests" / "examples" / "upload.json", "r")
+    user = UserFactory()
+
+    consultation = upload_consultation(file, user)
+
+    assert consultation.section_set.count() == 1
+
+    section = consultation.section_set.first()
+    assert section.question_set.count() == 2
+
+    assert consultation.consultationresponse_set.count() == 2
+
+    response = consultation.consultationresponse_set.all()[0]
+    answers = Answer.objects.filter(consultation_response=response).all()
+    assert answers.count() == 2
+
+    response = consultation.consultationresponse_set.all()[1]
+    answers = Answer.objects.filter(consultation_response=response).all()
+    assert answers.count() == 2
+

--- a/tests/unit/test_upload_consultation.py
+++ b/tests/unit/test_upload_consultation.py
@@ -21,9 +21,18 @@ def test_upload_consultation():
     assert consultation.consultationresponse_set.count() == 2
 
     response = consultation.consultationresponse_set.all()[0]
-    answers = Answer.objects.filter(consultation_response=response).all()
-    assert answers.count() == 2
+    r1_answers = Answer.objects.filter(consultation_response=response).all()
+    assert r1_answers.count() == 2
 
     response = consultation.consultationresponse_set.all()[1]
-    answers = Answer.objects.filter(consultation_response=response).all()
-    assert answers.count() == 2
+    r2_answers = Answer.objects.filter(consultation_response=response).all()
+    assert r2_answers.count() == 2
+
+    for a in Answer.objects.all():
+        q = a.question
+        assert a.free_text in ["Answer to Question 1", "Answer to Question 2"]
+        if q.text == "Question 1":
+            assert a.free_text == "Answer to Question 1"
+        elif q.text == "Question 2":
+            assert a.free_text == "Answer to Question 2"
+

--- a/tests/unit/test_upload_consultation.py
+++ b/tests/unit/test_upload_consultation.py
@@ -27,4 +27,3 @@ def test_upload_consultation():
     response = consultation.consultationresponse_set.all()[1]
     answers = Answer.objects.filter(consultation_response=response).all()
     assert answers.count() == 2
-

--- a/tests/views/test_consultation_scoping.py
+++ b/tests/views/test_consultation_scoping.py
@@ -9,11 +9,11 @@ from consultation_analyser.factories import ConsultationFactory, UserFactory
 @pytest.mark.django_db
 def test_get_consultation_we_own():
     user = UserFactory()
-    consultation_we_own = ConsultationFactory(user=user)
+    consultation_we_own = ConsultationFactory(user=user, with_themes=True)
 
     request_factory = RequestFactory()
 
-    valid_request = request_factory.get("/consultations/slug-does-not-matter-here")
+    valid_request = request_factory.get("/consultations/slug-does-not-matter-here/")
     valid_request.user = user
     resp = consultations.show(valid_request, consultation_slug=consultation_we_own.slug)
 
@@ -27,7 +27,7 @@ def test_get_consultation_we_do_not_own():
 
     request_factory = RequestFactory()
 
-    invalid_request = request_factory.get("/consultations/slug-does-not-matter-here")
+    invalid_request = request_factory.get("/consultations/slug-does-not-matter-here/")
     invalid_request.user = user
 
     # rest of Django not around to catch 404 so we'll catch it ourselves


### PR DESCRIPTION
**Depends on #172**

## Context

Users need to be able to upload their consultations so they can be processed. This PR adds that feature.

## Changes proposed in this pull request

The flow:

1. User logs in
2. User sees green upload button
3. User gets a form to upload their JSON
4. On successful upload, user sees a holding page until
5. We process the consultation
6. Consultation becomes visible

Note that users can only have one consultation — we don't allow them to upload another.

Email notification will follow in another PR.

### Uploading a consultation

<img width="1004" alt="Screenshot 2024-05-07 at 16 57 49" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/c4cc78c3-84bf-4ddf-a5f7-733b234a1847">

### Uploading a consultation with malformed JSON

![Screenshot 2024-05-03 at 12 48 47](https://github.com/i-dot-ai/consultation-analyser/assets/642279/c197bc36-c077-4e7d-9a70-b06d1716b045)

## Guidance to review

- try and get some error messages
- `tests/examples/upload.json` is used as a valid upload example in tests and will work via the frontend too

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-62

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo