### PR TITLE
Feature/associate dummy data to user

### DIFF
--- a/consultation_analyser/consultations/dummy_data.py
+++ b/consultation_analyser/consultations/dummy_data.py
@@ -13,51 +13,51 @@ from consultation_analyser.factories import (
 from consultation_analyser.hosting_environment import HostingEnvironment
 
 
-class DummyConsultation:
-    def __init__(self, responses=10, include_themes=True, number_questions=10, **options):
-        if number_questions > 10:
-            raise RuntimeError("You can't have more than 10 questions")
-        if not HostingEnvironment.is_development_environment():
-            raise RuntimeError("Dummy data generation should only be run in development")
+def create_dummy_data(responses=10, include_themes=True, number_questions=10, **options):
+    if number_questions > 10:
+        raise RuntimeError("You can't have more than 10 questions")
+    if not HostingEnvironment.is_development_environment():
+        raise RuntimeError("Dummy data generation should only be run in development")
 
-        # Timestamp to avoid duplicates - set these as default options
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-        if "name" not in options:
-            options["name"] = f"Dummy consultation generated at {timestamp}"
-        if "slug" not in options:
-            options["slug"] = f"consultation-slug-{timestamp}"
+    # Timestamp to avoid duplicates - set these as default options
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    if "name" not in options:
+        options["name"] = f"Dummy consultation generated at {timestamp}"
+    if "slug" not in options:
+        options["slug"] = f"consultation-slug-{timestamp}"
 
-        consultation = ConsultationFactory(**options)
-        section = SectionFactory(name="Base section", consultation=consultation)
-        all_questions = FakeConsultationData().all_questions()
-        questions_to_include = all_questions[:number_questions]
-        questions = [
-            QuestionFactory(
-                text=q["text"],
-                slug=q["slug"],
-                multiple_choice_options=q.get("multiple_choice_options", None),
-                has_free_text=q["has_free_text"],
-                section=section,
-            )
-            for q in questions_to_include
-        ]
-        for r in range(responses):
-            response = ConsultationResponseFactory(consultation=consultation)
-            if include_themes:
-                _answers = [AnswerFactory(question=q, consultation_response=response) for q in questions]
+    consultation = ConsultationFactory(**options)
+    section = SectionFactory(name="Base section", consultation=consultation)
+    all_questions = FakeConsultationData().all_questions()
+    questions_to_include = all_questions[:number_questions]
+    questions = [
+        QuestionFactory(
+            text=q["text"],
+            slug=q["slug"],
+            multiple_choice_options=q.get("multiple_choice_options", None),
+            has_free_text=q["has_free_text"],
+            section=section,
+        )
+        for q in questions_to_include
+    ]
+    for r in range(responses):
+        response = ConsultationResponseFactory(consultation=consultation)
+        if include_themes:
+            _answers = [AnswerFactory(question=q, consultation_response=response) for q in questions]
 
-                # Set themes per question, multiple answers with the same theme
-                for q in questions:
-                    themes = [ThemeFactory() for _ in range(4)]
-                    for a in _answers:
-                        random_theme = random.choice(themes)
-                        a.theme = random_theme
-                        a.save()
-                # Force at least one answer to be an outlier
-                a = random.choice(_answers)
-                theme = a.theme
-                theme.is_outlier = True
-                theme.save()
+            # Set themes per question, multiple answers with the same theme
+            for q in questions:
+                themes = [ThemeFactory() for _ in range(4)]
+                for a in _answers:
+                    random_theme = random.choice(themes)
+                    a.theme = random_theme
+                    a.save()
+            # Force at least one answer to be an outlier
+            a = random.choice(_answers)
+            theme = a.theme
+            theme.is_outlier = True
+            theme.save()
 
-            else:
-                _answers = [AnswerFactory(question=q, consultation_response=response, theme=None) for q in questions]
+        else:
+            _answers = [AnswerFactory(question=q, consultation_response=response, theme=None) for q in questions]
+    return consultation

--- a/consultation_analyser/consultations/management/commands/generate_dummy_data.py
+++ b/consultation_analyser/consultations/management/commands/generate_dummy_data.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.utils.text import slugify
 
-from consultation_analyser.consultations.dummy_data import DummyConsultation
+from consultation_analyser.consultations.dummy_data import create_dummy_data
 
 
 class Command(BaseCommand):
@@ -15,8 +15,8 @@ class Command(BaseCommand):
         if options["name"]:
             name = options["name"]
             slug = slugify(name)
-            DummyConsultation(name=options["name"], slug=slug)
+            create_dummy_data(name=options["name"], slug=slug)
         else:
-            DummyConsultation()
+            create_dummy_data()
 
         self.stdout.write("Done.")

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -12,7 +12,12 @@ from consultation_analyser.pipeline.processing import run_processing_pipeline
 def index(request: HttpRequest) -> HttpResponse:
     if request.POST:
         try:
-            dummy_data.DummyConsultation(include_themes=False, number_questions=2)
+            dummy_data.DummyConsultation(include_themes=False, number_questions=10)
+            # Assume that the consultation generated is the latest one.
+            # Likely to be true as this is only used in testing/dev environments.
+            consultations = models.Consultation.objects.all().order_by("created_at").last()
+            user = request.user
+            consultations.users.add(user)
             messages.success(request, "A dummy consultation has been generated")
         except RuntimeError as error:
             messages.error(request, error.args[0])

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -15,9 +15,10 @@ def index(request: HttpRequest) -> HttpResponse:
             dummy_data.DummyConsultation(include_themes=False, number_questions=10)
             # Assume that the consultation generated is the latest one.
             # Likely to be true as this is only used in testing/dev environments.
-            consultations = models.Consultation.objects.all().order_by("created_at").last()
-            user = request.user
-            consultations.users.add(user)
+            consultation = models.Consultation.objects.all().order_by("created_at").last()
+            if consultation.name.startswith("Dummy consultation"):  # Double-check it's a dummy one.
+                user = request.user
+                consultation.users.add(user)
             messages.success(request, "A dummy consultation has been generated")
         except RuntimeError as error:
             messages.error(request, error.args[0])

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -3,7 +3,8 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
-from consultation_analyser.consultations import dummy_data, models
+from consultation_analyser.consultations import models
+from consultation_analyser.consultations.dummy_data import create_dummy_data
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.pipeline.processing import run_processing_pipeline
 
@@ -12,13 +13,9 @@ from consultation_analyser.pipeline.processing import run_processing_pipeline
 def index(request: HttpRequest) -> HttpResponse:
     if request.POST:
         try:
-            dummy_data.DummyConsultation(include_themes=False, number_questions=10)
-            # Assume that the consultation generated is the latest one.
-            # Likely to be true as this is only used in testing/dev environments.
-            consultation = models.Consultation.objects.all().order_by("created_at").last()
-            if consultation.name.startswith("Dummy consultation"):  # Double-check it's a dummy one.
-                user = request.user
-                consultation.users.add(user)
+            consultation = create_dummy_data(include_themes=False, number_questions=10)
+            user = request.user
+            consultation.users.add(user)
             messages.success(request, "A dummy consultation has been generated")
         except RuntimeError as error:
             messages.error(request, error.args[0])

--- a/tests/integration/test_support_console_pages.py
+++ b/tests/integration/test_support_console_pages.py
@@ -1,6 +1,6 @@
 import pytest
 
-from consultation_analyser.consultations.dummy_data import DummyConsultation
+from consultation_analyser.consultations.dummy_data import create_dummy_data
 from consultation_analyser.consultations.models import Consultation, Theme
 from consultation_analyser.factories import UserFactory
 
@@ -50,7 +50,7 @@ def test_generating_dummy_data(django_app):
 
 @pytest.mark.django_db
 def test_generate_themes(django_app):
-    DummyConsultation(name="Test consultation", slug="test-consultation", include_themes=False)
+    create_dummy_data(name="Test consultation", slug="test-consultation", include_themes=False)
     UserFactory(email="email@example.com", password="admin", is_staff=True)  # pragma: allowlist secret
     login_page = django_app.get("/support/consultations/test-consultation/").follow()
     login_page.form["username"] = "email@example.com"

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from consultation_analyser.consultations.dummy_data import DummyConsultation
+from consultation_analyser.consultations.dummy_data import create_dummy_data
 from consultation_analyser.consultations.models import Answer, Consultation, Question
 
 
@@ -12,7 +12,7 @@ from consultation_analyser.consultations.models import Answer, Consultation, Que
 def test_a_consultation_is_generated(settings):
     assert Consultation.objects.count() == 0
 
-    DummyConsultation()
+    create_dummy_data()
 
     assert Consultation.objects.count() == 1
     assert Question.objects.count() == 10
@@ -24,11 +24,11 @@ def test_a_consultation_is_generated(settings):
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"should only be run in development"):
-            DummyConsultation()
+            create_dummy_data()
 
 
 @pytest.mark.django_db
 def test_consultation_contains_outliers():
-    DummyConsultation()
+    create_dummy_data()
     qs = Answer.objects.filter(theme__is_outlier=True)
     assert qs.exists()


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Associate the dummy consultation to the user that generated it. Only for dev environments for testing.

Just to make testing easier so you don't have to associate a user to a consultation.
Also generate dummy data for 10 questions - to get better themes.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
As above.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo