### PR TITLE
Feature/Delete consultations

### DIFF
--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -35,6 +35,17 @@ class Consultation(UUIDPrimaryKeyModel, TimeStampedModel):
     class Meta(UUIDPrimaryKeyModel.Meta, TimeStampedModel.Meta):
         pass
 
+    def delete(self, *args, **kwargs):
+        """
+        Delete Related theme objects that can become orphans
+        because deletes will not cascade from Answer because
+        the Theme in question could still be associated with
+        another Answer
+        """
+        Theme.objects.filter(answer__question__section__consultation=self).delete()
+
+        super().delete(*args, **kwargs)
+
 
 class Section(UUIDPrimaryKeyModel, TimeStampedModel):
     consultation = models.ForeignKey(Consultation, on_delete=models.CASCADE)

--- a/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
@@ -5,27 +5,31 @@
 
 {% block content %}
   <h1 class="govuk-heading-l">{{ page_title }}</h1>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Consultation name</th>
-        <th scope="col" class="govuk-table__header">Created at</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-    {% for consultation in consultations %}
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
-          <a href="{{ url('support_consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-link--no-visited-state">
-            {{ consultation.name }}
-          </a>
-        </td>
-        <td class="govuk-table__cell">
-          {{ consultation.created_at }}
-        </td>
-      </tr>
-    {% endfor %}
-  </table>
+  {% if consultations %}
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Consultation name</th>
+          <th scope="col" class="govuk-table__header">Created at</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+      {% for consultation in consultations %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <a href="{{ url('support_consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-link--no-visited-state">
+              {{ consultation.name }}
+            </a>
+          </td>
+          <td class="govuk-table__cell">
+            {{ consultation.created_at }}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% else %}
+    <p class="govuk-body">There are no consultations in the system.</p>
+  {% endif %}
   <form method="post" novalidate>{{ csrf_input }}
     {% if development_env %}
       {{ govukButton({

--- a/consultation_analyser/support_console/jinja2/support_console/consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultation.html
@@ -14,9 +14,17 @@
       <p class="govuk-body">There are no themes for this consultation.</p>
     {% endif %}
 
-    <a href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-body govuk-link--no-visited-state">
-      View on frontend
-    </a>
+    <p class="govuk-body">
+      <a href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-body govuk-link--no-visited-state">
+        View on frontend
+      </a>
+    </p>
+
+    <p class="govuk-body">
+      <a href="{{ url('delete_consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-link--warning govuk-body">
+        Delete this consultation
+      </a>
+    </p>
 
   </div>
 

--- a/consultation_analyser/support_console/jinja2/support_console/delete-consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/delete-consultation.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% set page_title = "Delete consultation" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">{{ page_title }}</h1>
+  <div>
+    <p class="govuk-body">Are you sure you want to delete this consultation:</p>
+    <p class="govuk-body">{{ consultation.name }}</p>
+  </div>
+
+  <br />
+
+  <form method="post" novalidate>{{ csrf_input }}
+    {{ govukButton({
+      'text': "Yes, delete it",
+      'name': "confirm_deletion",
+      'classes': "govuk-button--warning"
+    }) }}
+  </form>
+
+{% endblock %}

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("users/<int:user_id>", users.show),
     path("consultations/", consultations.index),
     path("consultations/<str:consultation_slug>/", consultations.show, name="support_consultation"),
+    path("consultations/<str:consultation_slug>/delete", consultations.delete, name="delete_consultation"),
 ]

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 
 from consultation_analyser.consultations import models
 from consultation_analyser.consultations.download_consultation import consultation_to_json
@@ -24,6 +24,22 @@ def index(request: HttpRequest) -> HttpResponse:
     consultations = models.Consultation.objects.all()
     context = {"consultations": consultations, "development_env": HostingEnvironment.is_development_environment()}
     return render(request, "support_console/all-consultations.html", context=context)
+
+
+@staff_member_required
+def delete(request: HttpRequest, consultation_slug: str) -> HttpResponse:
+    consultation = models.Consultation.objects.get(slug=consultation_slug)
+    context = {
+        "consultation": consultation,
+    }
+
+    if request.POST:
+        if "confirm_deletion" in request.POST:
+            consultation.delete()
+            messages.success(request, "The consultation has been deleted")
+            return redirect("/support/consultations/")
+
+    return render(request, "support_console/delete-consultation.html", context=context)
 
 
 @staff_member_required

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -33,6 +33,14 @@ $iai-colour-pink: #C50878;
     padding-top: 0;
 }
 
+.govuk-link.govuk-link--warning {
+  color: $govuk-error-colour;
+
+  &:visited {
+    color: $govuk-error-colour;
+  }
+}
+
 /* HOMEPAGE */
 
 .x-govuk-masthead {

--- a/tests/commands/test_dummy_data.py
+++ b/tests/commands/test_dummy_data.py
@@ -1,10 +1,11 @@
+import os
 from io import StringIO
 from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
 
-from consultation_analyser.consultations.models import Consultation
+from consultation_analyser.consultations import models
 
 
 @pytest.mark.django_db
@@ -16,6 +17,24 @@ def test_name_parameter_sets_consultation_name(mock_is_local):
         stdout=StringIO(),  # we'll ignore this
     )
 
-    assert Consultation.objects.count() == 1
-    assert Consultation.objects.first().name == "My special consultation"
-    assert Consultation.objects.first().slug == "my-special-consultation"
+    assert models.Consultation.objects.count() == 1
+    assert models.Question.objects.count() == 10
+    assert models.Answer.objects.count() == 100
+
+    qs = models.Answer.objects.filter(theme__is_outlier=True)
+    assert qs.exists()
+
+    assert models.Consultation.objects.first().name == "My special consultation"
+    assert models.Consultation.objects.first().slug == "my-special-consultation"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("environment", ["preprod", "prod", "production"])
+def test_the_tool_will_only_run_in_dev(environment):
+    with patch.dict(os.environ, {"ENVIRONMENT": environment}):
+        with pytest.raises(Exception, match=r"should only be run in development"):
+            call_command(
+                "generate_dummy_data",
+                name="My special consultation",
+                stdout=StringIO(),  # we'll ignore this
+            )

--- a/tests/integration/test_managing_consultations_via_support.py
+++ b/tests/integration/test_managing_consultations_via_support.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+from waffle.testutils import override_switch
+
+from consultation_analyser.consultations.models import Consultation
+from consultation_analyser.factories import UserFactory
+from tests.helpers import sign_in
+
+
+@pytest.mark.django_db
+@override_switch("FRONTEND_USER_LOGIN", True)
+def test_managing_consultations_via_support(django_app):
+    # given I am an admin user
+    user = UserFactory(email="email@example.com", is_staff=True)
+    sign_in(django_app, user.email)
+
+    # when I generate a dummy consultation
+    consultations_page = django_app.get("/support/consultations/")
+    consultations_page = consultations_page.form.submit("generate_dummy_consultation")
+
+    latest_consultation = Consultation.objects.all().order_by("created_at").last()
+    consultation_page = consultations_page.click(latest_consultation.name)
+
+    # then I should be able to download the JSON
+    json_download = consultation_page.forms[0].submit("download_json")
+    exported_data = json.loads(json_download.text)
+    assert exported_data["consultation"]["name"] == latest_consultation.name
+
+    # and I should be able to delete the consultation
+    confirmation_page = consultation_page.click("Delete this consultation")
+    consultations_page = confirmation_page.form.submit("confirm_deletion").follow()
+
+    assert "The consultation has been deleted" in consultations_page

--- a/tests/integration/test_support_console_pages.py
+++ b/tests/integration/test_support_console_pages.py
@@ -27,28 +27,6 @@ def test_logging_in_to_support(django_app):
 
 
 @pytest.mark.django_db
-def test_generating_dummy_data(django_app):
-    page_url = "/support/consultations/"
-    UserFactory(email="email@example.com", password="admin", is_staff=True)  # pragma: allowlist secret
-    login_page = django_app.get(page_url).follow()
-    login_page.form["username"] = "email@example.com"
-    login_page.form["password"] = "admin"  # pragma: allowlist secret
-    consultations_page = login_page.form.submit().follow()
-    assert "Consultations" in consultations_page
-
-    # Check dummy data button does generate a new consultation
-    initial_count = Consultation.objects.all().count()
-    consultations_page = consultations_page.form.submit("generate_dummy_consultation")
-    count_after_dummy_data = Consultation.objects.all().count()
-    assert count_after_dummy_data > initial_count
-
-    # Check redirected to individual consultation page in support
-    latest_consultation = Consultation.objects.all().order_by("created_at").last()
-    next_page = consultations_page.click(latest_consultation.name)
-    assert "Generate themes" in next_page
-
-
-@pytest.mark.django_db
 def test_generate_themes(django_app):
     create_dummy_data(name="Test consultation", slug="test-consultation", include_themes=False)
     UserFactory(email="email@example.com", password="admin", is_staff=True)  # pragma: allowlist secret

--- a/tests/integration/test_support_console_pages.py
+++ b/tests/integration/test_support_console_pages.py
@@ -1,8 +1,7 @@
 import pytest
 
-from consultation_analyser.consultations.dummy_data import create_dummy_data
-from consultation_analyser.consultations.models import Consultation, Theme
-from consultation_analyser.factories import UserFactory
+from consultation_analyser.consultations.models import Consultation, ConsultationResponse, Question, Theme
+from consultation_analyser.factories import AnswerFactory, ConsultationFactory, UserFactory
 
 
 @pytest.mark.django_db
@@ -24,17 +23,3 @@ def test_logging_in_to_support(django_app):
     logged_out_page = support_home.click("Sign out")
 
     assert "Consultation analyser support console" not in logged_out_page
-
-
-@pytest.mark.django_db
-def test_generate_themes(django_app):
-    create_dummy_data(name="Test consultation", slug="test-consultation", include_themes=False)
-    UserFactory(email="email@example.com", password="admin", is_staff=True)  # pragma: allowlist secret
-    login_page = django_app.get("/support/consultations/test-consultation/").follow()
-    login_page.form["username"] = "email@example.com"
-    login_page.form["password"] = "admin"  # pragma: allowlist secret
-    consultation_page = login_page.form.submit().follow()
-    assert "Test consultation" in consultation_page
-    consultation_page = consultation_page.forms[1].submit("generate_themes")
-    generated_themes = Theme.objects.filter(answer__question__section__consultation__slug="test-consultation")
-    assert generated_themes.exists()

--- a/tests/unit/test_delete_consultation.py
+++ b/tests/unit/test_delete_consultation.py
@@ -1,0 +1,25 @@
+import pytest
+
+from consultation_analyser.consultations import models
+from consultation_analyser.factories import ConsultationFactory
+
+
+@pytest.mark.django_db
+def test_delete_consultation():
+    consultation = ConsultationFactory(with_themes=True)
+
+    assert models.Consultation.objects.count() == 1
+    assert models.ConsultationResponse.objects.count() == 1
+    assert models.Section.objects.count() == 1
+    assert models.Question.objects.count() == 1
+    assert models.Answer.objects.count() == 1
+    assert models.Theme.objects.count() == 1
+
+    consultation.delete()
+
+    assert models.Consultation.objects.count() == 0
+    assert models.ConsultationResponse.objects.count() == 0
+    assert models.Section.objects.count() == 0
+    assert models.Question.objects.count() == 0
+    assert models.Answer.objects.count() == 0
+    assert models.Theme.objects.count() == 0

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -18,6 +18,9 @@ def test_a_consultation_is_generated(settings):
     assert Question.objects.count() == 10
     assert Answer.objects.count() == 100
 
+    qs = Answer.objects.filter(theme__is_outlier=True)
+    assert qs.exists()
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("environment", ["preprod", "prod", "production"])
@@ -25,10 +28,3 @@ def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"should only be run in development"):
             create_dummy_data()
-
-
-@pytest.mark.django_db
-def test_consultation_contains_outliers():
-    create_dummy_data()
-    qs = Answer.objects.filter(theme__is_outlier=True)
-    assert qs.exists()


### PR DESCRIPTION
## Context

We are going to make mistakes with our uploads. Make it very easy to delete consultations via support.

## Changes proposed in this pull request

- support deletion, including a fun edge case around orphaned `Theme`s
- add an end-to-end test for this and #181 (this branch contains an e2e test that will pass once rebased on there)
- deduplicate some other tests, most controversially deleting the test which runs the ML pipeline from support (I think we can revisit that once #170 is in and we're looking at refactoring — perhaps we can have it run against a mock and leave `test_ml_pipeline` to do its thing). Tests now run ~20s faster.

## Guidance to review

Generate a consultation, delete one, repeat until satisfied.

## Link to JIRA ticket

Supporting data upload/download

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo