### PR TITLE
Batch job name must be in certain format.

### DIFF
--- a/consultation_analyser/pipeline/processing.py
+++ b/consultation_analyser/pipeline/processing.py
@@ -14,7 +14,7 @@ def process_consultation_themes(consultation):
 
 def run_processing_pipeline(consultation):
     if HostingEnvironment.is_deployed():
-        job_name = f"Theme processing pipeline for consultation: {consultation.slug}"
+        job_name = f"generate-themes-{consultation.slug}"[:128]  # Must be <=128 , no spaces
         command = {"command": ["venv/bin/django-admin", "run_ml_pipeline", "--slug", consultation.slug]}
         batch_handler = BatchJobHandler()
         batch_handler.submit_job_batch(jobName=job_name, containerOverrides=command)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The batch job name was in an invalid format causing this bug: https://i-dot-ai.sentry.io/issues/5358256475/?project=4507153305239552&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
N/A

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Probs easiest to deploy to test. Check that the `job_name` fits format in docs: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch/client/submit_job.html

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo