### PR TITLE
Feature/upload

### DIFF
--- a/consultation_analyser/consultations/jinja2/all-consultations.html
+++ b/consultation_analyser/consultations/jinja2/all-consultations.html
@@ -14,6 +14,11 @@
           </a>
         </li>
       {% endfor %}
+      {% if is_staff %}
+        <a href="/consultations/new/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
+          Upload a consultation
+        </a>
+      {% endif %}
     {% else %}
       <p class="govuk-body">You do not have any consultations</p>
       <a href="/consultations/new/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">

--- a/consultation_analyser/consultations/jinja2/all-consultations.html
+++ b/consultation_analyser/consultations/jinja2/all-consultations.html
@@ -14,6 +14,7 @@
           </a>
         </li>
       {% endfor %}
+      <br>
       {% if is_staff %}
         <a href="/consultations/new/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
           Upload a consultation

--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -13,7 +13,9 @@ from .decorators import user_can_see_consultation
 @login_required
 def index(request: HttpRequest) -> HttpResponse:
     consultations = request.user.consultation_set.all()
-    context = {"consultations": consultations}
+    user = request.user
+    is_staff = user.is_staff
+    context = {"consultations": consultations, "is_staff": is_staff}
     return render(request, "all-consultations.html", context)
 
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Allow staff users to upload more than one consultation - to make testing easier.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Before:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/10cb2891-eb16-404a-a3c1-64411f4444eb)



After (only if users are "staff" i.e. access to support console):
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/c36384dc-3046-447e-8a05-c3798f58e62c)

Standard users - no change.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Have already checked with a staff/non-staff user that the button appears/doesn't appear when the user has an existing consultation.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo