### PR TITLE
Only send magic link when not running locally.

### DIFF
--- a/consultation_analyser/consultations/views/sessions.py
+++ b/consultation_analyser/consultations/views/sessions.py
@@ -21,7 +21,8 @@ def send_magic_link_if_email_exists(request: HttpRequest, email: str) -> None:
         if HostingEnvironment.is_local():
             logger = logging.getLogger("django.server")
             logger.info(f"##################### Sending magic link to {email}: {magic_link}")
-        send_magic_link_email(email, magic_link)
+        else:
+            send_magic_link_email(email, magic_link)
     except User.DoesNotExist:
         pass
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Only send magic link when not running locally - means we don't get error.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-190

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo