### PR TITLE
Feature/delete using UUID

### DIFF
--- a/consultation_analyser/support_console/jinja2/support_console/consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultation.html
@@ -38,12 +38,6 @@
       </p>
     </div>
 
-    <div>
-      <a href="{{ url('consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-body govuk-link govuk-link--no-visited-state">
-        {{ consultation.name }}
-      </a>
-    </div>
-
     <br>
     {{ govukButton({
       'text': "Download JSON",

--- a/consultation_analyser/support_console/jinja2/support_console/consultation.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultation.html
@@ -21,7 +21,7 @@
     </p>
 
     <p class="govuk-body">
-      <a href="{{ url('delete_consultation', kwargs={'consultation_slug': consultation.slug}) }}" class="govuk-link govuk-link--warning govuk-body">
+      <a href="{{ url('delete_consultation', kwargs={'consultation_id': consultation.id}) }}" class="govuk-link govuk-link--warning govuk-body">
         Delete this consultation
       </a>
     </p>

--- a/consultation_analyser/support_console/urls.py
+++ b/consultation_analyser/support_console/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     path("users/<int:user_id>", users.show),
     path("consultations/", consultations.index),
     path("consultations/<uuid:consultation_id>/", consultations.show, name="support_consultation"),
-    path("consultations/<str:consultation_slug>/delete", consultations.delete, name="delete_consultation"),
+    path("consultations/<uuid:consultation_id>/delete", consultations.delete, name="delete_consultation"),
 ]

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -29,8 +29,8 @@ def index(request: HttpRequest) -> HttpResponse:
 
 
 @staff_member_required
-def delete(request: HttpRequest, consultation_slug: str) -> HttpResponse:
-    consultation = models.Consultation.objects.get(slug=consultation_slug)
+def delete(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
+    consultation = models.Consultation.objects.get(id=consultation_id)
     context = {
         "consultation": consultation,
     }


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Delete based on UUID as it's guaranteed unique.

Also delete duplicate link to view consultation on frontend.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Before:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/69ee97aa-bee9-4a56-8a69-26afa3f74474)

After:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/06956844-6337-4016-b91b-84f02aafef8a)

## Guidance to review

Check that you can delete a consultation in the support section.  Go to `/support/consultations/` - click on an individual consultation and delete.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo