### PR TITLE
Use Docker Cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ tf_build_args=-var "image_tag=$(IMAGE_TAG)"
 .PHONY: docker_build
 docker_build: ## Pull previous container (if it exists) build the docker container
 	docker pull $(PREV_IMAGE) || true
-	docker build . -t $(IMAGE)
+	docker build . -t $(IMAGE) --cache-from=type=local,src=/tmp/.build-cache
 
 .PHONY: docker_run
 docker_run: ## Run the docker container


### PR DESCRIPTION
## Context

This change will use add caching parameter in `docker build`. The caching is added in core git hub action repo.
https://github.com/i-dot-ai/i-dot-ai-core-github-actions/pull/16

## Changes proposed in this pull request

No UI changes

## Guidance to review

Make sure docker build GitHub actions are not failing and using cache. 

## Link to JIRA ticket

https://github.com/i-dot-ai/i-ai-core-infrastructure/issues/261

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo