### PR TITLE
Pin langchain to < v1 as need to refactor older code.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       # Don't update to 2.3 as doesn't work on older Macs
       - dependency-name: "torch"
         versions: ["2.3"]
+      # Don't update to 1.x yet, as we need to refactor some of the code
+      - dependency-name: "langchain"
+        versions: ["1.x"]
     groups:
       pip-updates:
         update-types:


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Moving to v1 of langchain will break code - need to refactor LLM pipeline first.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Pin langchain to < v1.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does it look right? GitHub dependabot docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-disabling-version-updates-for-some-dependencies

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A