### PR TITLE
Also use preprod as a development environment.

### DIFF
--- a/consultation_analyser/consultations/dummy_data.py
+++ b/consultation_analyser/consultations/dummy_data.py
@@ -16,8 +16,8 @@ from consultation_analyser.hosting_environment import HostingEnvironment
 def create_dummy_data(responses=10, include_themes=True, number_questions=10, **options):
     if number_questions > 10:
         raise RuntimeError("You can't have more than 10 questions")
-    if not HostingEnvironment.is_development_environment():
-        raise RuntimeError("Dummy data generation should only be run in development")
+    if HostingEnvironment.is_production():
+        raise RuntimeError("Dummy data generation should not be run in production")
 
     # Timestamp to avoid duplicates - set these as default options
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")

--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -15,13 +15,12 @@ class HostingEnvironment:
     @staticmethod
     def is_deployed() -> bool:
         environment = env.str("ENVIRONMENT", "").upper()
-        deployed_envs = ["DEV", "DEVELOPMENT", "PREPROD", "PROD", "PRODUCTION"]
+        deployed_envs = ["DEV", "DEVELOPMENT", "PREPROD", "PROD"]
         return environment in deployed_envs
 
     @staticmethod
     def is_production() -> bool:
-        environment = env.str("ENVIRONMENT", "").upper()
-        return environment in ["PROD", "PRODUCTION"]
+        return env.str("ENVIRONMENT", "").upper() == "PROD"
 
     @staticmethod
     def is_development_environment() -> bool:

--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -19,7 +19,12 @@ class HostingEnvironment:
         return environment in deployed_envs
 
     @staticmethod
+    def is_production() -> bool:
+        environment = env.str("ENVIRONMENT", "").upper()
+        return environment in ["PROD", "PRODUCTION"]
+
+    @staticmethod
     def is_development_environment() -> bool:
         environment = env.str("ENVIRONMENT", "").upper()
-        development_environments = ["LOCAL", "TEST", "DEV", "DEVELOPMENT", "PREPROD"]
+        development_environments = ["LOCAL", "TEST", "DEV", "DEVELOPMENT"]
         return environment in development_environments

--- a/consultation_analyser/hosting_environment.py
+++ b/consultation_analyser/hosting_environment.py
@@ -21,5 +21,5 @@ class HostingEnvironment:
     @staticmethod
     def is_development_environment() -> bool:
         environment = env.str("ENVIRONMENT", "").upper()
-        development_environments = ["LOCAL", "TEST", "DEV", "DEVELOPMENT"]
+        development_environments = ["LOCAL", "TEST", "DEV", "DEVELOPMENT", "PREPROD"]
         return environment in development_environments

--- a/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
@@ -31,7 +31,7 @@
     <p class="govuk-body">There are no consultations in the system.</p>
   {% endif %}
   <form method="post" novalidate>{{ csrf_input }}
-    {% if development_env %}
+    {% if not production_env %}
       {{ govukButton({
         'text': "Generate dummy consultation",
         'name': "generate_dummy_consultation"

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -24,7 +24,7 @@ def index(request: HttpRequest) -> HttpResponse:
         except RuntimeError as error:
             messages.error(request, error.args[0])
     consultations = models.Consultation.objects.all()
-    context = {"consultations": consultations, "development_env": HostingEnvironment.is_development_environment()}
+    context = {"consultations": consultations, "production_env": HostingEnvironment.is_production()}
     return render(request, "support_console/all-consultations.html", context=context)
 
 

--- a/tests/commands/test_dummy_data.py
+++ b/tests/commands/test_dummy_data.py
@@ -29,7 +29,7 @@ def test_name_parameter_sets_consultation_name(mock_is_local):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("environment", ["prod", "production"])
+@pytest.mark.parametrize("environment", ["prod"])
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"Dummy data generation should not be run in production"):

--- a/tests/commands/test_dummy_data.py
+++ b/tests/commands/test_dummy_data.py
@@ -32,7 +32,7 @@ def test_name_parameter_sets_consultation_name(mock_is_local):
 @pytest.mark.parametrize("environment", ["prod", "production"])
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
-        with pytest.raises(Exception, match=r"should only be run in development"):
+        with pytest.raises(Exception, match=r"Dummy data generation should not be run in production"):
             call_command(
                 "generate_dummy_data",
                 name="My special consultation",

--- a/tests/commands/test_dummy_data.py
+++ b/tests/commands/test_dummy_data.py
@@ -29,7 +29,7 @@ def test_name_parameter_sets_consultation_name(mock_is_local):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("environment", ["preprod", "prod", "production"])
+@pytest.mark.parametrize("environment", ["prod", "production"])
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"should only be run in development"):

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -23,7 +23,7 @@ def test_a_consultation_is_generated(settings):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("environment", ["prod", "production"])
+@pytest.mark.parametrize("environment", ["prod"])
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"Dummy data generation should not be run in production"):

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -23,7 +23,7 @@ def test_a_consultation_is_generated(settings):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("environment", ["preprod", "prod", "production"])
+@pytest.mark.parametrize("environment", ["prod", "production"])
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
         with pytest.raises(Exception, match=r"should only be run in development"):

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -26,5 +26,5 @@ def test_a_consultation_is_generated(settings):
 @pytest.mark.parametrize("environment", ["prod", "production"])
 def test_the_tool_will_only_run_in_dev(environment):
     with patch.dict(os.environ, {"ENVIRONMENT": environment}):
-        with pytest.raises(Exception, match=r"should only be run in development"):
+        with pytest.raises(Exception, match=r"Dummy data generation should not be run in production"):
             create_dummy_data()


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We need dummy data to test on pre-prod - allow us to generate dummy data there for testing.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Have checked (locally) that setting `ENVIRONMENT` to `preprod` allows us to generate dummy data, but we can't when `ENVIRONMENT` is set to `prod`.

Are we ok with generating dummy data on prod? I think yes, as it's easy for us to delete data.

Is the function in `HostingEnvironment` now mis-named?

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A