### PR TITLE
Update docker build to add caching params

### DIFF
--- a/.github/.github.env
+++ b/.github/.github.env
@@ -8,3 +8,5 @@ DJANGO_SECRET_KEY=dummy-key # pragma: allowlist secret
 
 REPO=consultation-analyser
 INFRA_CONFIG_REPO=consultation-analyser-infra-config
+
+DOCKER_BUILD_INSTANCE=consultations

--- a/.github/workflows/build-gh.yml
+++ b/.github/workflows/build-gh.yml
@@ -34,7 +34,6 @@ jobs:
         with:
             EC2_INSTANCE_TYPE: ${{ needs.set-vars.outputs.ec2-instance-type }}
             RUNNER_SIZE: ${{ needs.set-vars.outputs.runner-size }}
-            ENVIRONMENT: preprod
         secrets:
             AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
             AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}
@@ -45,7 +44,7 @@ jobs:
     needs:
       - set-vars
       - start-runner
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@docker-cache
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}

--- a/.github/workflows/build-gh.yml
+++ b/.github/workflows/build-gh.yml
@@ -13,6 +13,7 @@ jobs:
       ec2-instance-type: ${{ steps.export.outputs.ec2-instance-type }}
       version: ${{ steps.export.outputs.version }}
       runner-size: ${{ steps.export.outputs.runner-size }}
+      docker-build-instance: ${{ steps.export.outputs.docker-build-instance }}
 
 
     steps:
@@ -25,6 +26,7 @@ jobs:
           echo "app-name=${APP_NAME}" >> $GITHUB_OUTPUT
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "runner-size=${RUNNER_SIZE}" >> $GITHUB_OUTPUT
+          echo "docker-build-instance=${DOCKER_BUILD_INSTANCE}" >> $GITHUB_OUTPUT
 
   start-runner:
         uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/start-runner.yml@main
@@ -32,6 +34,7 @@ jobs:
         with:
             EC2_INSTANCE_TYPE: ${{ needs.set-vars.outputs.ec2-instance-type }}
             RUNNER_SIZE: ${{ needs.set-vars.outputs.runner-size }}
+            ENVIRONMENT: preprod
         secrets:
             AWS_GITHUBRUNNER_USER_ACCESS_KEY: ${{ secrets.AWS_GITHUBRUNNER_USER_ACCESS_KEY }}
             AWS_GITHUBRUNNER_USER_SECRET_ID: ${{ secrets.AWS_GITHUBRUNNER_USER_SECRET_ID }}
@@ -42,11 +45,12 @@ jobs:
     needs:
       - set-vars
       - start-runner
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@main
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/build-docker.yml@docker-cache
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}
       INFRASTRUCTURE_FOLDER: "infrastructure"
+      DOCKER_BUILD_INSTANCE: ${{ needs.set-vars.outputs.docker-build-instance }}
     secrets:
       AWS_GITHUBRUNNER_PAT: ${{ secrets.AWS_GITHUBRUNNER_PAT}}
       AWS_GITHUBRUNNER_PAT_USER: ${{ secrets.AWS_GITHUBRUNNER_PAT_USER }}


### PR DESCRIPTION
## Context

This change will use add caching parameter in docker build. The caching is added in core git hub action repo.
https://github.com/i-dot-ai/i-dot-ai-core-github-actions/pull/17

## Changes proposed in this pull request

1. Update docker_build command and add caching params to cache it to s3 bucket.
2. The bucket is added as part of following PR
https://github.com/i-dot-ai/i-ai-core-infrastructure/pull/266

## Guidance to review

1. Make sure docker build GitHub actions are not failing and using cache.

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/browse/EN-1

## Things to check

- [x] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo