### PR TITLE
Feature/Format datetimes nicely in Support

### DIFF
--- a/consultation_analyser/jinja2.py
+++ b/consultation_analyser/jinja2.py
@@ -10,6 +10,10 @@ def render_form(form, request):
     return render_to_string("form.html", context={"form": form}, request=request, using="django")
 
 
+def datetime(datetime_object):
+    return datetime_object.strftime("%d %B %Y at %H:%M")
+
+
 def environment(**options):
     current_loader = options["loader"]
     loader_with_govuk_frontend = ChoiceLoader(
@@ -24,7 +28,7 @@ def environment(**options):
 
     env = Environment(**options, extensions=[CompressorExtension])  # nosec
 
-    tags = {"static": static, "url": reverse, "render_form": render_form}
+    tags = {"static": static, "url": reverse, "render_form": render_form, "datetime": datetime}
 
     env.globals.update(tags)
 

--- a/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-consultations.html
@@ -22,7 +22,7 @@
             </a>
           </td>
           <td class="govuk-table__cell">
-            {{ consultation.created_at }}
+            {{ datetime(consultation.created_at) }}
           </td>
         </tr>
       {% endfor %}

--- a/consultation_analyser/support_console/jinja2/support_console/all-users.html
+++ b/consultation_analyser/support_console/jinja2/support_console/all-users.html
@@ -26,7 +26,7 @@
           <a class="govuk-link" href="/support/users/{{ user.id }}">{{ user.email }}</a>
         </td>
         <td class="govuk-table__cell">
-          {{ user.created_at }}
+          {{ datetime(user.created_at) }}
         </td>
         <td class="govuk-table__cell">
           {% if user.is_staff %}

--- a/consultation_analyser/support_console/jinja2/support_console/user.html
+++ b/consultation_analyser/support_console/jinja2/support_console/user.html
@@ -42,7 +42,7 @@
                   {{ consultation.name }}
                 </td>
                 <td class="govuk-table__cell">
-                  {{ consultation.created_at }}
+                  {{ datetime(consultation.created_at) }}
                 </td>
                 <td class="govuk-table__cell">
                   <a class="govuk-link" href="/support/consultations/{{ consultation.slug }}">View in support</a><br />


### PR DESCRIPTION
## Context

Datetimes are hard-to-parse ISO8601 strings.

## Changes proposed in this pull request

Use standard GOV.UK formatting

<img width="1014" alt="Screenshot 2024-05-22 at 14 23 50" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/51bd6ca6-8a9f-4712-87f1-7d2f298a680b">

## Guidance to review

Should be straightforward!

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo