### PR TITLE
Add IAM role

### DIFF
--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -14,6 +14,7 @@ module "batch_compute" {
   private_subnets = data.terraform_remote_state.vpc.outputs.private_subnets
   state_bucket    = var.state_bucket
   instance_type   = "g5.xlarge"
+  ecs_instance_role = aws_iam_role.ecs_instance_role.name
 }
 
 module "batch_job_definition" {

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -32,6 +32,7 @@ module "ecs" {
   image_tag          = var.image_tag
   ecr_repository_uri = var.ecr_repository_uri
   ecs_cluster_id     = data.terraform_remote_state.platform.outputs.ecs_cluster_id
+  ecs_cluster_name   = data.terraform_remote_state.platform.outputs.ecs_cluster_name
   health_check = {
     healthy_threshold   = 3
     unhealthy_threshold = 3
@@ -56,6 +57,7 @@ module "ecs" {
   additional_execution_role_tags = {
     "RolePassableByRunner" = "True"
   }
+  
 }
 
 resource "aws_route53_record" "type_a_record" {

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -1,0 +1,75 @@
+resource "aws_iam_role" "ecs_instance_role" {
+  name               = "${var.prefix}-${var.project_name}-${terraform.workspace}-ecs-execution-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
+}
+
+resource "aws_iam_policy" "ecs_instance_policy" {
+  name        = "consult_batch_execution_policy"
+  description = "Let batch invoke a sagemaker endpoint"
+  policy      = data.aws_iam_policy_document.ecs_instance_policy_document.json
+}
+
+resource "aws_iam_instance_profile" "ecs_instance_profile" {
+  name = "${var.prefix}-${var.project_name}-${terraform.workspace}-ecs-execution-task-role"
+  role = aws_iam_role.ecs_instance_role.name
+}
+
+resource "aws_iam_policy" "ecs_assume_batch_policy" {
+  name        = "${var.prefix}-${var.project_name}-${terraform.workspace}-ecs-assume-batch-policy"
+  description = "Policy to allow ECS role to assume AWS Batch role"
+  policy      = data.aws_iam_policy_document.ecs_assume_batch_policy_document.json
+}
+
+data "aws_iam_policy_document" "ecs_assume_batch_policy_document" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "arn:aws:iam::671657536603:role/AWSServiceRoleForBatch"
+    ]
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_assume_batch_policy_attachment" {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = aws_iam_policy.ecs_assume_batch_policy.arn
+}
+
+data "aws_iam_policy_document" "ecs_instance_policy_document" {
+  statement {
+    actions = [
+      "ec2:DescribeTags",
+      "ecs:CreateCluster",
+      "ecs:DeregisterContainerInstance",
+      "ecs:DiscoverPollEndpoint",
+      "ecs:Poll",
+      "ecs:RegisterContainerInstance",
+      "ecs:StartTelemetrySession",
+      "ecs:UpdateContainerInstancesState",
+      "ecs:Submit*",
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "sagemaker:CreateEndpoint",
+      "sagemaker:InvokeEndpoint"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "ecs_assume_role_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "ecs_assume_batch_policy_document" {
   statement {
     actions = ["sts:AssumeRole"]
     resources = [
-      "arn:aws:iam::671657536603:role/AWSServiceRoleForBatch"
+      "arn:aws:iam::${account_id}:role/AWSServiceRoleForBatch"
     ]
     effect = "Allow"
   }

--- a/infrastructure/postgres.tf
+++ b/infrastructure/postgres.tf
@@ -11,5 +11,5 @@ module "postgres" {
   state_bucket            = var.state_bucket
   service_sg_ids          = [module.ecs.ecs_sg_id]
   publicly_accessible     = var.publicly_accessible
-  securelist_ips          = var.developer_ips
+  securelist_ips          = concat(var.developer_ips, var.internal_ips)
 }


### PR DESCRIPTION
## Context

- When attempting to call the `CreateEndpoint` operation for SageMaker from Batch, an exception of type `AccessDeniedException` is being thrown.

## Changes proposed in this pull request

- Create a new IAM role specifically for consultations, which includes the necessary base batch roles and permissions for creating SageMaker endpoints

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

- Review IAM roles and the variables used to create it. 

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/browse/CON-225

## Things to check

- If we are able call the `CreateEndpoint` operation for SageMaker from Batch

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo