### PR TITLE
Make support messages for running themes a bit more accurate.

### DIFF
--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -56,13 +56,13 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
             from consultation_analyser.pipeline.ml_pipeline import save_themes_for_consultation
 
             save_themes_for_consultation(consultation_id)
-            messages.success(request, "Topic modelling has been run for this consultation")
+            messages.success(request, "Topic modelling has started for this consultation")
         elif "llm_summarisation" in request.POST:
             create_llm_summaries_for_consultation(consultation)
-            messages.success(request, "Summaries have been generated for themes using the LLM")
+            messages.success(request, "Themes have been sent to the LLM for summarisation")
         elif "generate_themes" in request.POST:
             run_processing_pipeline(consultation)
-            messages.success(request, "Themes have been generated for this consultation")
+            messages.success(request, "Consultation data has been sent for processing and generating themes")
         elif "download_json" in request.POST:
             consultation_json = consultation_to_json(consultation)
             response = HttpResponse(consultation_json, content_type="application/json")

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -62,7 +62,7 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
             messages.success(request, "Themes have been sent to the LLM for summarisation")
         elif "generate_themes" in request.POST:
             run_processing_pipeline(consultation)
-            messages.success(request, "Consultation data has been sent for processing and generating themes")
+            messages.success(request, "Consultation data has been sent for processing")
         elif "download_json" in request.POST:
             consultation_json = consultation_to_json(consultation)
             response = HttpResponse(consultation_json, content_type="application/json")


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Make the messages when generating themes a bit more accurate. In a deployed environment we currently get a message saying "themes have been generated" when all we have is sent the consultation to Batch for processing. 

(Longer-term we will do something better than this.)

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/724ae632-6492-4088-935d-09b9e64493dd)


These messages are only for internal use in the support console.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo