### PR TITLE
Feature/write topic models to disk

### DIFF
--- a/consultation_analyser/consultations/management/commands/evaluate.py
+++ b/consultation_analyser/consultations/management/commands/evaluate.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import os
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Optional
 
 from django.conf import settings
@@ -19,7 +19,6 @@ from consultation_analyser.pipeline.backends.dummy_topic_backend import DummyTop
 from consultation_analyser.pipeline.backends.ollama_llm_backend import OllamaLLMBackend
 from consultation_analyser.pipeline.backends.sagemaker_llm_backend import SagemakerLLMBackend
 from consultation_analyser.pipeline.processing import process_consultation_themes
-
 
 logger = logging.getLogger("pipeline")
 
@@ -64,7 +63,9 @@ class Command(BaseCommand):
         output_dir = self.__get_output_dir(
             output_dir=options["output_dir"], consultation=consultation
         )
-        topic_backend = self.__get_topic_backend(embedding_model=options["embedding_model"], persistence_path=output_dir)
+        topic_backend = self.__get_topic_backend(
+            embedding_model=options["embedding_model"], persistence_path=output_dir
+        )
         llm_backend = self.__get_llm(llm_identifier=options["llm"])
 
         process_consultation_themes(
@@ -99,7 +100,9 @@ class Command(BaseCommand):
 
         return consultation
 
-    def __get_topic_backend(self, persistence_path: Path = None, embedding_model: Optional[str] = ""):
+    def __get_topic_backend(
+        self, persistence_path: Path = None, embedding_model: Optional[str] = ""
+    ):
         if embedding_model == "fake":
             topic_backend = DummyTopicBackend()
             logger.info("Using fake topic model")

--- a/consultation_analyser/consultations/management/commands/evaluate.py
+++ b/consultation_analyser/consultations/management/commands/evaluate.py
@@ -61,8 +61,10 @@ class Command(BaseCommand):
         logger.info(f"Called evaluate with {options}")
 
         consultation = self.__load_consultation(input_file=options["input"], clean=options["clean"])
-        output_dir = self.__get_output_dir(output_dir=options["output_dir"], consultation=consultation)
-        topic_backend = self.__get_topic_backend(embedding_model=options["embedding_model"])
+        output_dir = self.__get_output_dir(
+            output_dir=options["output_dir"], consultation=consultation
+        )
+        topic_backend = self.__get_topic_backend(embedding_model=options["embedding_model"], persistence_path=output_dir)
         llm_backend = self.__get_llm(llm_identifier=options["llm"])
 
         process_consultation_themes(
@@ -97,14 +99,16 @@ class Command(BaseCommand):
 
         return consultation
 
-    def __get_topic_backend(self, embedding_model: Optional[str] = ""):
+    def __get_topic_backend(self, persistence_path: Path = None, embedding_model: Optional[str] = ""):
         if embedding_model == "fake":
             topic_backend = DummyTopicBackend()
             logger.info("Using fake topic model")
         elif embedding_model:
-            topic_backend = BERTopicBackend(embedding_model=embedding_model)
+            topic_backend = BERTopicBackend(
+                embedding_model=embedding_model, persistence_path=persistence_path / "bertopic"
+            )
         else:
-            topic_backend = BERTopicBackend()
+            topic_backend = BERTopicBackend(persistence_path=persistence_path / "bertopic")
 
         return topic_backend
 
@@ -134,4 +138,3 @@ class Command(BaseCommand):
         f = open(output_dir / "consultation_with_themes.json", "w")
         f.write(json_with_themes)
         f.close()
-

--- a/consultation_analyser/pipeline/backends/bertopic.py
+++ b/consultation_analyser/pipeline/backends/bertopic.py
@@ -18,9 +18,7 @@ logger = logging.getLogger("pipeline")
 
 class BERTopicBackend(TopicBackend):
     def __init__(
-        self,
-        embedding_model: Optional[str] = None,
-        persistence_path: Optional[str] = None
+        self, embedding_model: Optional[str] = None, persistence_path: Optional[str] = None
     ):
         if not embedding_model:
             embedding_model = settings.BERTOPIC_DEFAULT_EMBEDDING_MODEL

--- a/consultation_analyser/pipeline/backends/bertopic.py
+++ b/consultation_analyser/pipeline/backends/bertopic.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("pipeline")
 
 class BERTopicBackend(TopicBackend):
     def __init__(
-        self, embedding_model: Optional[str] = None, persistence_path: Optional[str] = None
+        self, embedding_model: Optional[str] = None, persistence_path: Optional[Path] = None
     ):
         if not embedding_model:
             embedding_model = settings.BERTOPIC_DEFAULT_EMBEDDING_MODEL
@@ -63,8 +63,16 @@ class BERTopicBackend(TopicBackend):
         return assignments
 
     def __persist(self, subpath: str):
+        # satisfy mypy
+        if not self.persistence_path:
+            return
+
         output_dir = Path(self.persistence_path) / subpath
         os.makedirs(output_dir, exist_ok=True)
+
+        if not self.topic_model:
+            raise Exception("You cannot persist the topic model until you have run get_topics")
+
         self.topic_model.save(
             output_dir,
             serialization="safetensors",

--- a/consultation_analyser/pipeline/backends/dummy_llm_backend.py
+++ b/consultation_analyser/pipeline/backends/dummy_llm_backend.py
@@ -7,9 +7,8 @@ from .langchain_llm_backend import LangchainLLMBackend
 
 class DummyLLMBackend(LangchainLLMBackend):
     def __init__(self, responses: Optional[list[str]] = None):
+        resp = '{ "short_description": "Example short description", "summary": "Example summary" }'
         if not responses:
-            responses = [
-                '{"short description": "Example short description", "summary": "Example summary"}'
-            ]
+            responses = [resp]
         llm = FakeListLLM(responses=responses)
         super().__init__(llm)

--- a/consultation_analyser/pipeline/backends/dummy_topic_backend.py
+++ b/consultation_analyser/pipeline/backends/dummy_topic_backend.py
@@ -25,8 +25,3 @@ class DummyTopicBackend(TopicBackend):
             topic_id += 1
 
         return assignments
-
-    def save_topic_model(self, output_dir) -> None:
-        f = open(output_dir / "GENERATED_WITH_DUMMY_TOPIC_MODEL.txt", "w")
-        f.write("This output was generated with a dummy topic model")
-        f.close()

--- a/consultation_analyser/pipeline/backends/topic_backend.py
+++ b/consultation_analyser/pipeline/backends/topic_backend.py
@@ -9,7 +9,3 @@ class TopicBackend(ABC):
     @abstractmethod
     def get_topics(self, question: models.Question) -> list[TopicAssignment]:
         pass
-
-    @abstractmethod
-    def save_topic_model(self, output_dir):
-        pass

--- a/consultation_analyser/pipeline/bertopic_persistence.py
+++ b/consultation_analyser/pipeline/bertopic_persistence.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+
+
+class BERTopicPersistence:
+    def __init__(self, path: Path):
+        self.path = path
+
+    def persist(self, model, embedding_model, subpath):
+        output_dir = self.path / subpath
+        os.makedirs(output_dir, exist_ok=True)
+        self.topic_model.save(
+            output_dir,
+            serialization="safetensors",
+            save_ctfidf=True,
+            save_embedding_model=self.embedding_model,
+        )

--- a/consultation_analyser/pipeline/llm_summariser.py
+++ b/consultation_analyser/pipeline/llm_summariser.py
@@ -5,7 +5,7 @@ from consultation_analyser.pipeline.backends.llm_backend import LLMBackend
 
 from .backends.types import ThemeSummary
 
-logger = logging.getLogger("django.server")
+logger = logging.getLogger("pipeline")
 
 
 def create_llm_summaries_for_consultation(consultation, llm_backend: LLMBackend):
@@ -18,6 +18,7 @@ def create_llm_summaries_for_consultation(consultation, llm_backend: LLMBackend)
 
     theme: ThemeSummary
     for theme in themes:
+        logger.info(f"Starting LLM summarisation for theme with keywords: {theme.topic_keywords}")
         theme_summary_data = llm_backend.summarise_theme(theme)
         theme.summary = theme_summary_data.summary
         theme.short_description = theme_summary_data.short_description

--- a/consultation_analyser/pipeline/ml_pipeline.py
+++ b/consultation_analyser/pipeline/ml_pipeline.py
@@ -5,12 +5,13 @@ from consultation_analyser.consultations import models
 
 from .backends.topic_backend import TopicBackend
 
-logger = logging.getLogger("django.server")
+logger = logging.getLogger("pipeline")
 
 
 def save_themes_for_question(question: models.Question, topic_backend: TopicBackend) -> None:
     logging.info(f"Get topics for question: {question.text}")
     assignments = topic_backend.get_topics(question)
+
     for assignment in assignments:
         assignment.answer.save_theme_to_answer(
             topic_keywords=assignment.topic_keywords, topic_id=assignment.topic_id

--- a/consultation_analyser/pipeline/processing.py
+++ b/consultation_analyser/pipeline/processing.py
@@ -1,4 +1,5 @@
 import logging
+
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.pipeline.backends.bertopic import BERTopicBackend
 from consultation_analyser.pipeline.backends.dummy_llm_backend import DummyLLMBackend

--- a/consultation_analyser/pipeline/processing.py
+++ b/consultation_analyser/pipeline/processing.py
@@ -1,3 +1,4 @@
+import logging
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.pipeline.backends.bertopic import BERTopicBackend
 from consultation_analyser.pipeline.backends.dummy_llm_backend import DummyLLMBackend
@@ -6,6 +7,8 @@ from consultation_analyser.pipeline.llm_summariser import (
     create_llm_summaries_for_consultation,
 )
 from consultation_analyser.pipeline.ml_pipeline import save_themes_for_consultation
+
+logger = logging.getLogger("pipeline")
 
 
 def process_consultation_themes(consultation, topic_backend=None, llm_backend=None):

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -12,8 +12,8 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 import logging
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import environ
 

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 import logging
 import os
 from pathlib import Path
+import sys
 
 import environ
 
@@ -164,6 +165,30 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 ]
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "pipeline": {
+            "()": "django.utils.log.ServerFormatter",
+            "format": "[{server_time}] {name}: {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "stdout": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+            "formatter": "pipeline",
+        }
+    },
+    "loggers": {
+        "pipeline": {"handlers": ["stdout"], "level": "INFO", "propagate": False},
+    },
+}
+
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/tests/integration/test_local_eval.py
+++ b/tests/integration/test_local_eval.py
@@ -1,5 +1,4 @@
 import json
-import os
 
 import pytest
 from django.conf import settings

--- a/tests/integration/test_local_eval.py
+++ b/tests/integration/test_local_eval.py
@@ -18,9 +18,6 @@ def test_local_eval(tmp_path):
     call_command("evaluate", input=file_path, embedding_model="fake", output_dir=tmp_path)
 
     json_with_themes_path = tmp_path / "consultation_with_themes.json"
-    serialized_model = tmp_path / "GENERATED_WITH_DUMMY_TOPIC_MODEL.txt"
-
-    assert os.path.isfile(serialized_model)
 
     with_themes = json.loads(open(json_with_themes_path).read())
 

--- a/tests/integration/test_ml_pipeline.py
+++ b/tests/integration/test_ml_pipeline.py
@@ -30,9 +30,6 @@ def test_topic_model_end_to_end(tmp_path):
     backend = BERTopicBackend()
     save_themes_for_consultation(consultation.id, backend)
 
-    backend.save_topic_model(tmp_path)
-    assert os.path.isfile(tmp_path / "bertopic/topic_embeddings.safetensors")
-
     # all answers should get the same theme
     assert models.Theme.objects.count() == 1
 

--- a/tests/integration/test_ml_pipeline.py
+++ b/tests/integration/test_ml_pipeline.py
@@ -1,5 +1,3 @@
-import os.path
-
 import pytest
 
 from consultation_analyser import factories


### PR DESCRIPTION
## Context

During eval, we want to keep hold of all the topic models we create.

This PR causes them all to be written to disk as part of the `evaluate` command.

## Changes proposed in this pull request

- refactor the `evaluate` command so it's possible to work with it
- introduce saving via the constructor of the `BERTopic` backend

## Guidance to review

The logging is harmless to merge along with this so review in preference to #235.

Only the penultimate commit does any new work, the rest is logging and refactoring.

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo