### PR TITLE
Bugfix/Require env= arg in make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,12 @@ tf_import:
 # Release commands to deploy your app to AWS
 .PHONY: release
 release: ## Deploy app
+## bail if env is not set
+	@if [ -z "$(env)" ]; then \
+		echo "make release requires an env= argument"; \
+		exit 1; \
+	fi
+
 	chmod +x ./infrastructure/scripts/release.sh && ./infrastructure/scripts/release.sh $(env)
 
 


### PR DESCRIPTION
## Context

It's possible to "release" without an env, but this doesn't make sense

## Changes proposed in this pull request

Error out instead.

## Guidance to review

Try `make release` with and without `env=`

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo