### PR TITLE
Passes the minimum spec for vCPUs and memory to batch job definition.

### DIFF
--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -17,14 +17,16 @@ module "batch_compute" {
 }
 
 module "batch_job_definition" {
-  source                  = "../../i-ai-core-infrastructure/modules/batch/batch_job_definitons"
-  name                    = local.name
-  compute_environment_arn = [module.batch_compute.ec2_compute_environment_arn]
-  state_bucket            = var.state_bucket
-  image                   = "${local.batch_image_ecr_url}:${var.image_tag}"
-  fargate_flag            = false
-  env_vars                = local.batch_env_vars
-  additional_iam_policy   = aws_iam_policy.batch.arn
+  source                   = "../../i-ai-core-infrastructure/modules/batch/batch_job_definitons"
+  name                     = local.name
+  compute_environment_arn  = [module.batch_compute.ec2_compute_environment_arn]
+  state_bucket             = var.state_bucket
+  image                    = "${local.batch_image_ecr_url}:${var.image_tag}"
+  fargate_flag             = false
+  env_vars                 = local.batch_env_vars
+  additional_iam_policy    = aws_iam_policy.batch.arn
+  task_memory_requirements = local.memory
+  task_vcpu_requirements   = local.vcpus
 }
 
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -21,6 +21,12 @@ variable "cpu" {
   description = "The cpu resource to give to the task"
 }
 
+variable "vcpus" {
+  type        = number
+  description = "The number of vcpus to give to the task."
+  default     = 2
+}
+
 variable "developer_ips" {
   type        = list(string)
   description = "List of developer IPs"


### PR DESCRIPTION
## Context

While the change was made to up the default values for CPUs and memory, the batch_job_definition wasn't being initialised with these values in the TF.

## Changes proposed in this pull request

Init the module with the values and creates a new vCPU local var to pass in number of CPUs as opposed to MiBs.

## Guidance to review

Check happy with the TF and ensure it can be applied correctly. Also that it matches up with the infra core code for batch job definitions: https://github.com/i-dot-ai/i-ai-core-infrastructure/blob/1155acdd07784632196b284de17b18977c338187/modules/batch/batch_job_definitons/main.tf