### PR TITLE
Show times in London not UTC

### DIFF
--- a/consultation_analyser/jinja2.py
+++ b/consultation_analyser/jinja2.py
@@ -3,6 +3,7 @@ from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.urls import reverse
+from django.utils import timezone
 from jinja2 import ChoiceLoader, Environment, PackageLoader, PrefixLoader
 
 
@@ -11,7 +12,9 @@ def render_form(form, request):
 
 
 def datetime(datetime_object):
-    return datetime_object.strftime("%d %B %Y at %H:%M")
+    tz = timezone.get_current_timezone()
+    with_tz = datetime_object.astimezone(tz)
+    return with_tz.strftime("%d %B %Y at %H:%M")
 
 
 def environment(**options):

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -145,7 +145,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-gb"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/London"
 
 USE_I18N = True
 


### PR DESCRIPTION
## Context

This was wrong.

## Changes proposed in this pull request

Always use the configured timezone (which is now `Europe/London`) when rendering datetimes on the front end.

## Guidance to review

Create a dummy consultation in support and see it now has a timestamp matching its name.

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo