### PR TITLE
Adds hash to the base GUI template

### DIFF
--- a/consultation_analyser/consultations/jinja2/base.html
+++ b/consultation_analyser/consultations/jinja2/base.html
@@ -38,9 +38,10 @@
           {{ app_config.name }}
         </a>
       </div>
+      <div class="iai-release-tag-badge">{{app_config.release_hash}}</div>
     </div>
 
-    <div class="iai-phase-banner">
+    <div class="iai-phase-banner"> 
       <div class="govuk-width-container">
         {{ govukPhaseBanner({
           "tag": {
@@ -94,7 +95,7 @@
           {
             "href": "https://www.smartsurvey.co.uk/s/consultation-interest/",
             "text": "Register your interest"
-          },
+          }
         ]
       }
     ],
@@ -107,7 +108,6 @@
       ]
     }
   }) }}
-
 </body>
 
 </html>

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from django.http import HttpRequest
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
+from django.conf import settings
 
 
 @dataclass
@@ -10,13 +11,14 @@ class AppConfig:
     name: str
     path: str
     menu_items: list
+    release_hash: str
 
 
 def app_config(request: HttpRequest):
     try:
         resolved_url = resolve(request.path)
     except Resolver404:
-        return {"app_config": AppConfig(name="Consult", path="/", menu_items=[])}
+        return {"app_config": AppConfig(name="Consult", path="/", menu_items=[], release_hash=settings.RELEASE_HASH)}
 
     current_app = resolved_url.func.__module__.split(".")[1]
 
@@ -86,6 +88,6 @@ def app_config(request: HttpRequest):
                 },
             ]
 
-        app_config = AppConfig(name="Consult", path="/", menu_items=menu_items)
+        app_config = AppConfig(name="Consult", path="/", menu_items=menu_items, release_hash=settings.RELEASE_HASH)
 
     return {"app_config": app_config}

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 
+from django.conf import settings
 from django.http import HttpRequest
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
-from django.conf import settings
 
 
 @dataclass

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -43,6 +43,7 @@ def app_config(request: HttpRequest):
                     "classes": "x-govuk-primary-navigation__item--right",
                 },
             ],
+            release_hash=settings.RELEASE_HASH
         )
     else:
         if request.user.is_authenticated:

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -28,6 +28,7 @@ env = environ.Env(DEBUG=(bool, False))
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 DEBUG = env("DEBUG")
 ENVIRONMENT = env("ENVIRONMENT")
+RELEASE_HASH = os.getenv("RELEASE_HASH", "Local Build")
 
 
 ALLOWED_HOSTS: list[str] = [os.getenv("DOMAIN_NAME", "0.0.0.0"), "*"]  # nosec

--- a/frontend/style.scss
+++ b/frontend/style.scss
@@ -38,6 +38,16 @@ $iai-colour-pink: #C50878;
     padding-top: 0;
 }
 
+.iai-release-tag-badge {
+    background-color: transparent;
+    color: lightgray;
+    padding: 10px 10px;
+    font-size: 12px;
+    white-space: nowrap;
+    max-width: fit-content;
+    float: inline-end;
+}
+
 .govuk-link.govuk-link--warning {
   color: $govuk-error-colour;
 

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -12,7 +12,8 @@ locals {
     "SENTRY_DSN"                           = local.secret_env_vars.SENTRY_DSN,
     "AWS_REGION"                           = local.secret_env_vars.AWS_REGION,
     "DATABASE_URL"                         = local.rds_fqdn,
-    "DOMAIN_NAME"                          = "${local.host}"
+    "DOMAIN_NAME"                          = "${local.host}",
+    "RELEASE_HASH"                         = substr(var.image_tag, 0, 6)
   }
 
 


### PR DESCRIPTION
## Context

To give greater context of the current build in use when deployed.

## Changes proposed in this pull request

Adds the image hash via the image tag to the web GUI.

## Guidance to review

Does this approach work, and are we happy with this positioning?

Could probably do with some conditional logic to exclude this from production builds.