### PR TITLE
Fix warnings in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,10 @@ docker_update_tag:
 docker_echo:
 	echo $($(value))
 
-ifeq ($(instance),postgres) then
+ifeq ($(instance),postgres)
 CONFIG_DIR=../../../consultation-analyser-infra-config
 tf_build_args=
-else ifeq ($(instance),universal) then
+else ifeq ($(instance),universal)
 CONFIG_DIR=../../../consultation-analyser-infra-config
 env=prod
 else
@@ -215,7 +215,7 @@ tf_destroy: ## Destroy terraform
 .PHONY: tf_import
 tf_import:
 	make tf_set_workspace && \
-	terraform -chdir=./infrastructure/$(instance) import ${tf_build_args} -var-file=$(CONFIG_DIR)/${env}-input-params.tfvars ${name} ${id} 
+	terraform -chdir=./infrastructure/$(instance) import ${tf_build_args} -var-file=$(CONFIG_DIR)/${env}-input-params.tfvars ${name} ${id}
 
 # Release commands to deploy your app to AWS
 .PHONY: release


### PR DESCRIPTION
## Context

These warnings showed on running any `make` command:

```
Makefile:159: Extraneous text after `ifeq' directive
Makefile:162: Extraneous text after `ifeq' directive
```

I think because GNU make doesn't require a `then` after an `ifeq`:

https://www.gnu.org/software/make/manual/html_node/Conditional-Example.html

## Changes proposed in this pull request

Remove the `then`s

## Guidance to review

This should still build and deploy ok!

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo