### PR TITLE
Feature/DummyLLM derives its output from the given Theme

### DIFF
--- a/consultation_analyser/pipeline/backends/dummy_llm_backend.py
+++ b/consultation_analyser/pipeline/backends/dummy_llm_backend.py
@@ -1,14 +1,19 @@
-from typing import Optional
+import faker
 
-from langchain_community.llms import FakeListLLM
+from consultation_analyser.consultations import models
 
-from .langchain_llm_backend import LangchainLLMBackend
+from .llm_backend import LLMBackend
+from .types import ThemeSummary
 
 
-class DummyLLMBackend(LangchainLLMBackend):
-    def __init__(self, responses: Optional[list[str]] = None):
-        resp = '{ "short_description": "Example short description", "summary": "Example summary" }'
-        if not responses:
-            responses = [resp]
-        llm = FakeListLLM(responses=responses)
-        super().__init__(llm)
+class DummyLLMBackend(LLMBackend):
+    def __init__(self):
+        self.faker = faker.Faker()
+
+    def summarise_theme(self, theme: models.Theme) -> ThemeSummary:
+        return ThemeSummary(
+            **{
+                "short_description": ", ".join(theme.topic_keywords),
+                "summary": self.faker.sentence(),
+            }
+        )


### PR DESCRIPTION
## Context

The DummyLLM gave the same response for all Themes. Much better (and easier to work with on the front end!) when it derives the theme short_description from the keywords.

## Changes proposed in this pull request

Implement that.

## Guidance to review

Run `pr python manage.py evaluate --input=tests/examples/upload.json --clean --llm=fake --embedding_model=fake` and see reasonable summaries on the logs.

## Link to JIRA ticket

Towards https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-282

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo