### PR TITLE
Add additional policy to batch compute

### DIFF
--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -14,6 +14,7 @@ module "batch_compute" {
   private_subnets = data.terraform_remote_state.vpc.outputs.private_subnets
   state_bucket    = var.state_bucket
   instance_type   = "g5.xlarge"
+  additional_iam_policy   = aws_iam_policy.batch.arn
 }
 
 module "batch_job_definition" {

--- a/infrastructure/batch.tf
+++ b/infrastructure/batch.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "batch" {
     actions = [
       "sagemaker:CreateEndpoint",
       "sagemaker:InvokeEndpoint",
+      "sagemaker:DescribeEndpoint"
     ]
     resources = [
       "*"


### PR DESCRIPTION
## Context

When attempting to call the CreateEndpoint operation for SageMaker from Batch, an exception of type AccessDeniedException is being thrown.

## Changes proposed in this pull request

Add additional IAM role for SageMaker to batch_compute

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

If we are able call the CreateEndpoint operation for SageMaker from Batch

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo