### PR TITLE
Feature/link to responses

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/questions/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/show.html
@@ -124,6 +124,9 @@
                       {% endfor %}
                     </ul>
                   </div>
+                  <p class="govuk-body"><a class="govuk-link" href="{{ url("question_responses", kwargs={"consultation_slug":
+                      consultation_slug, "question_slug" : question.slug, "section_slug" : question.section.slug},
+                      query_kwargs={"theme": theme.id}) }}">View responses</a></p>
                 </details>
               </td>
               <td class="govuk-table__cell">

--- a/consultation_analyser/consultations/jinja2/consultations/questions/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/show.html
@@ -69,22 +69,6 @@
               </select>
             </div>
 
-          {% if question.multiple_choice_options %}
-            <div class="govuk-form-group">
-              <label class="govuk-label" for="opinion">
-                Opinion
-              </label>
-              <select class="govuk-select" id="opinion" name="opinion">
-                <option {% if applied_filters.opinion == "All" %}selected{% endif %}>All</option>
-                {% for item in question.multiple_choice_options %}
-                  {% for opt in item["options"] %}
-                    <option {% if applied_filters.opinion == opt %}selected{% endif %}>{{ opt }}</option>
-                  {% endfor %}
-                {% endfor %}
-              </select>
-            </div>
-          {% endif %}
-
           {{ govukButton({
             "text": "Apply filters",
             "classes": "govuk-!-margin-bottom-2"

--- a/consultation_analyser/consultations/jinja2/consultations/responses/index.html
+++ b/consultation_analyser/consultations/jinja2/consultations/responses/index.html
@@ -45,20 +45,6 @@
               </select>
             </div>
 
-          {% if question.multiple_choice_options %}
-            <div class="govuk-form-group">
-              <label class="govuk-label" for="opinion">
-                Opinion
-              </label>
-              <select class="govuk-select" id="opinion" name="opinion">
-                <option {% if applied_filters.opinion == "All" %}selected{% endif %}>All</option>
-                {% for option in question.multiple_choice_options %}
-                  <option {% if applied_filters.opinion == option %}selected{% endif %}>{{ option }}</option>
-                {% endfor %}
-              </select>
-            </div>
-          {% endif %}
-
           {{ govukButton({
             "text": "Apply filters",
             "classes": "govuk-!-margin-bottom-2"

--- a/consultation_analyser/consultations/views/filters.py
+++ b/consultation_analyser/consultations/views/filters.py
@@ -8,7 +8,6 @@ def get_applied_filters(request: HttpRequest) -> dict[str, str]:
     return {
         "keyword": request.GET.get("keyword", ""),
         "theme": request.GET.get("theme", "All"),
-        "opinion": request.GET.get("opinion", "All"),
     }
 
 
@@ -23,11 +22,6 @@ def get_filtered_responses(question: models.Question, applied_filters: dict[str,
         queryset = queryset.filter(free_text__contains=applied_filters["keyword"])
     if applied_filters["theme"] != "All":
         queryset = queryset.filter(theme=applied_filters["theme"])
-    if applied_filters["opinion"] != "All":
-        queryset = queryset.filter_multiple_choice(
-            question=question.multiple_choice_options[0]["question_text"],
-            answer=applied_filters["opinion"],
-        )
     return queryset
 
 
@@ -39,8 +33,4 @@ def get_filtered_themes(
     )
     if applied_filters["theme"] != "All":
         queryset = queryset.filter(id=applied_filters["theme"])
-    if applied_filters["opinion"] != "All":
-        unique_themes = filtered_answers.values("theme").distinct()
-        unique_themes_list = [item["theme"] for item in unique_themes]
-        queryset = queryset.filter(id__in=unique_themes_list)
     return queryset

--- a/consultation_analyser/jinja2.py
+++ b/consultation_analyser/jinja2.py
@@ -4,7 +4,17 @@ from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.http import urlencode
 from jinja2 import ChoiceLoader, Environment, PackageLoader, PrefixLoader
+
+
+def reverse_with_query_kwargs(viewname, kwargs=None, query_kwargs=None):
+    url = reverse(viewname, kwargs=kwargs)
+
+    if query_kwargs:
+        return f"{url}?{urlencode(query_kwargs)}"
+
+    return url
 
 
 def render_form(form, request):
@@ -36,7 +46,7 @@ def environment(**options):
 
     tags = {
         "static": static,
-        "url": reverse,
+        "url": reverse_with_query_kwargs,
         "render_form": render_form,
         "datetime": datetime,
     }

--- a/tests/integration/test_question_pages.py
+++ b/tests/integration/test_question_pages.py
@@ -67,8 +67,3 @@ def test_get_question_summary_page(django_app):
     assert re.search(r"Yes\s+50%", question_page.html.text)
     assert re.search(r"No\s+25%", question_page.html.text)
     assert re.search(r"Maybe\s+25%", question_page.html.text)
-
-    filtered_page = django_app.get(f"{question_summary_url}?opinion=Yes")
-    assert re.search(r"Yes\s+100%", filtered_page.html.text)
-    assert re.search(r"No\s+0%", filtered_page.html.text)
-    assert re.search(r"Maybe\s+0%", filtered_page.html.text)

--- a/tests/integration/test_responses_pages.py
+++ b/tests/integration/test_responses_pages.py
@@ -49,11 +49,6 @@ def test_get_question_responses_page(django_app):
     if answer.free_text:
         assert f"{answer.theme.short_description}" in page_content
 
-    # Opinions should appear in filter select-box
-    for item in question.multiple_choice_options:
-        for opt in item["options"]:
-            assert opt in page_content
-
     # Check keyword filtering
     first_word_of_answer = answer.free_text.split()[0]
     keywords = ["ThisWordWontAppear", first_word_of_answer]

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -10,7 +10,6 @@ def set_up_for_filters():
     consultation_response = factories.ConsultationResponseFactory(consultation=consultation)
     section = factories.SectionFactory(consultation=consultation)
     question = factories.QuestionFactory(
-        multiple_choice_questions=[("Select the animals you like", ["Cats", "Dogs", "Rabbits"])],
         section=section,
     )
 
@@ -20,14 +19,12 @@ def set_up_for_filters():
         theme=theme1,
         question=question,
         free_text="We love dogs.",
-        multiple_choice_answers=[("Select the animals you like", ["Cats", "Dogs"])],
         consultation_response=consultation_response,
     )
     factories.AnswerFactory(
         theme=theme2,
         question=question,
         free_text="We like cats not dogs.",
-        multiple_choice_answers=[("Select the animals you like", ["Cats"])],
         consultation_response=consultation_response,
     )
     factories.AnswerFactory(
@@ -35,12 +32,10 @@ def set_up_for_filters():
         question=question,
         free_text="We love cats.",
         consultation_response=consultation_response,
-        multiple_choice_answers=[("Select the animals you like", ["Cats"])],
     )
     factories.AnswerFactory(
         theme=theme2,
         question=question,
-        multiple_choice_answers=[("Select the animals you like", ["Rabbits"])],
         free_text=None,
         consultation_response=consultation_response,
     )
@@ -50,10 +45,9 @@ def set_up_for_filters():
 @pytest.mark.parametrize(
     "applied_filters,expected_count",
     [
-        ({"theme": "All", "keyword": "", "opinion": "All"}, 4),
-        ({"keyword": "dogs", "theme": "All", "opinion": "All"}, 2),
-        ({"keyword": "dogs", "theme": "All", "opinion": "Dogs"}, 1),
-        ({"theme": "All", "keyword": "", "opinion": "Cats"}, 3),
+        ({"keyword": "cats", "theme": "All"}, 2),
+        ({"keyword": "dogs", "theme": "All"}, 2),
+        ({"keyword": "", "theme": "All"}, 4),
     ],
 )
 @pytest.mark.django_db
@@ -68,7 +62,7 @@ def test_get_filtered_responses_themes():
     # Separate test, we need to get the theme ID from the generated theme
     question = set_up_for_filters()
     theme1 = models.Theme.objects.all().order_by("created_at").first()
-    applied_filters = {"keyword": "", "theme": theme1.id, "opinion": "All"}
+    applied_filters = {"keyword": "", "theme": theme1.id}
     queryset = filters.get_filtered_responses(question, applied_filters=applied_filters)
     assert queryset.count() == 1
     assert queryset[0].free_text == "We love dogs."
@@ -79,7 +73,7 @@ def test_get_filtered_themes():
     question = set_up_for_filters()
     answers_queryset = models.Answer.objects.all()
     theme2 = models.Theme.objects.all().order_by("created_at").last()
-    applied_filters = {"keyword": "", "theme": theme2.id, "opinion": "All"}
+    applied_filters = {"keyword": "", "theme": theme2.id}
     queryset = filters.get_filtered_themes(
         question=question, filtered_answers=answers_queryset, applied_filters=applied_filters
     )


### PR DESCRIPTION
## Context

There's currently no way to get to a theme's responses from the question page.

Also the "opinion" filter doesn't make sense with multiple multiple choice questions.

## Changes proposed in this pull request

Add a link.

### Link

<img width="1094" alt="Screenshot 2024-06-18 at 14 27 34" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/720723ee-0ff5-4047-a7cc-6292f5484a85">

Note "opinion" filter is gone too.

### Responses page

<img width="1079" alt="Screenshot 2024-06-18 at 14 27 43" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/efb8ec61-292a-4b63-be1a-578279a7be95">

The selected theme is selected on the left. Note opinion filter gone from here too.

## Guidance to review

Try it!

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-282

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo