### PR TITLE
Use pyproject.toml for python version throughout CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: install python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version-file: 'pyproject.toml'
 
       - name: install poetry & deps
         run: |


### PR DESCRIPTION
## Context

It's inconsistent and there's a newer python version than 3.12.3

## Changes proposed in this pull request

Always look at pyproject.toml when deciding which version of python to pass `setup-python`

## Guidance to review

Is it consistent?

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo