### PR TITLE
Fix python version conflicts in CI

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,15 +11,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: python:3.12
+    container: python:3.12.3
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: 'pyproject.toml'
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/release-infra.yml
+++ b/.github/workflows/release-infra.yml
@@ -67,7 +67,7 @@ jobs:
     needs:
       - set-vars
       - start-runner
-    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@test/apply-terraform.yml
+    uses: i-dot-ai/i-dot-ai-core-github-actions/.github/workflows/apply-terraform.yml@main
     with:
       APP_NAME: ${{ needs.set-vars.outputs.app-name }}
       RUNNER_LABEL: ${{ needs.start-runner.outputs.label }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: python:3.12
+    container: python:3.12.3
 
     services:
       postgres:
@@ -30,11 +30,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: install python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: 'pyproject.toml'
 
       - name: install poetry & deps
         run: |

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ MAIN_IMAGE_TAG=$$(git rev-parse origin/main)
 docker_build: ## Cache from the previous image and the head of main
 	docker buildx build --load --builder=$(DOCKER_BUILDER_CONTAINER) -t $(IMAGE)  \
 	--cache-to type=s3,region=$(AWS_REGION),bucket=$(DOCKER_CACHE_BUCKET),name=$(APP_NAME)/$(IMAGE) \
-	--cache-from type=s3,region=$(AWS_REGION),bucket=$(DOCKER_CACHE_BUCKET),name=$(APP_NAME)/$(ECR_REPO_URL):$(PREV_IMAGE_TAG) .
+	--cache-from type=s3,region=$(AWS_REGION),bucket=$(DOCKER_CACHE_BUCKET),name=$(APP_NAME)/$(ECR_REPO_URL):$(PREV_IMAGE_TAG) \
 	--cache-from type=s3,region=$(AWS_REGION),bucket=$(DOCKER_CACHE_BUCKET),name=$(APP_NAME)/$(ECR_REPO_URL):$(MAIN_IMAGE_TAG) .
 
 .PHONY: docker_run


### PR DESCRIPTION
Make the build consistent by specifying the exact version of python in the container that runs the tests.

Depends on #265 