### PR TITLE
Order themes by size

### DIFF
--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.decorators import login_required
-from django.db.models import Max
+from django.db.models import Count, Max
 from django.http import HttpRequest
 from django.shortcuts import render
 
@@ -18,7 +18,11 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
     )
     applied_filters = get_applied_filters(request)
     responses = get_filtered_responses(question, applied_filters)
-    filtered_themes = get_filtered_themes(question, responses, applied_filters)
+    filtered_themes = (
+        get_filtered_themes(question, responses, applied_filters)
+        .annotate(answer_count=Count("answer"))
+        .order_by("-answer_count")
+    )
 
     # Get counts
     total_responses = responses.count()


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Order themes by size.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Bars re-ordered by size (imagine some better named themes):
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/f7679c47-e241-49f4-b934-f2ac135168a3)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo