### PR TITLE
Add more options for chart colours.

### DIFF
--- a/frontend/scripts/summary-page.js
+++ b/frontend/scripts/summary-page.js
@@ -39,8 +39,11 @@ class donutChart extends HTMLElement {
         const options = {
             color: [
                 '#12436D',
+                '#28A197',
                 '#801650',
-                '#F46A25'
+                '#F46A25',
+                '#3D3D3D',
+                '#A285D1'
             ],
             tooltip: {
                 formatter: '{b} ({c}%)',


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
At the moment there are only 3 options for colours on the donut chart - there are often more than 3 options.

Have extended it to use all colours in the range specified here:
https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/

If there are more than 6 options, we should probably visualise it differently anyway.
Assume this will change anyway with new design changes, but I think fine in the meantime.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Before:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/b3f750e5-b602-498f-904c-b028798dd043)

After:

![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/fab46604-b8eb-4613-bc5c-69065a3ec164)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo