### PR TITLE
De-duplicate themes in dropdown

### DIFF
--- a/consultation_analyser/consultations/views/responses.py
+++ b/consultation_analyser/consultations/views/responses.py
@@ -16,7 +16,7 @@ def index(request: HttpRequest, consultation_slug: str, section_slug: str, quest
         section__slug=section_slug,
         section__consultation__slug=consultation_slug,
     )
-    themes_for_question = models.Theme.objects.filter(answer__question=question)
+    themes_for_question = models.Theme.objects.filter(answer__question=question).distinct()
     total_responses = models.Answer.objects.filter(question=question).count()
     applied_filters = get_applied_filters(request)
     responses = get_filtered_responses(question, applied_filters)


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We shouldn't have themes duplicated in the dropdown on the "Response explorer" page.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Before:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/85d8731b-5b75-423e-8230-34d271c43f84)

After:
![image](https://github.com/i-dot-ai/consultation-analyser/assets/77671865/5ff50a43-f35a-47bc-b43f-2084a8098987)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check the code makes sense.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
https://technologyprogramme.atlassian.net/browse/CON-290

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A