### PR TITLE
Fixes EXECUTION_CONTEXT typo

### DIFF
--- a/consultation_analyser/settings/production.py
+++ b/consultation_analyser/settings/production.py
@@ -5,7 +5,7 @@ from consultation_analyser.settings import base
 CSRF_TRUSTED_ORIGINS = ["https://" + base.env("DOMAIN_NAME")]
 
 SENTRY_DSN = base.env("SENTRY_DSN")
-EXECUTION_CONTENT = base.env("EXECUTION_CONTENT")
+EXECUTION_CONTEXT = base.env("EXECUTION_CONTEXT")
 GIT_SHA = base.env("GIT_SHA")
 
 sentry_sdk.init(
@@ -14,4 +14,4 @@ sentry_sdk.init(
     release=GIT_SHA,
 )
 
-sentry_sdk.set_tags({"execution_context": EXECUTION_CONTENT})
+sentry_sdk.set_tags({"execution_context": EXECUTION_CONTEXT})


### PR DESCRIPTION
## Context

References to env var EXECUTION_CONTEXT were mislabelled EXECUTION_CONTENT.

## Changes proposed in this pull request

Renaming var use in production.py