### PR TITLE
Add bigrams to CountVectorizer

### DIFF
--- a/consultation_analyser/pipeline/backends/bertopic.py
+++ b/consultation_analyser/pipeline/backends/bertopic.py
@@ -123,7 +123,7 @@ class BERTopicBackend(TopicBackend):
             cluster_selection_method="eom",
             prediction_data=True,
         )
-        vectorizer_model = CountVectorizer(stop_words="english")
+        vectorizer_model = CountVectorizer(stop_words="english", ngram_range=(1, 2))
         ctfidf_model = ClassTfidfTransformer()
         topic_model = BERTopic(
             umap_model=umap_model,


### PR DESCRIPTION
## Context

We're currently only extracting unigrams for the underlying topic modelling. It's quite common to see bigrams in human labelling. I think having both will help with distance measures of embeddings during evaluation and potentially improve topic quality.

## Changes proposed in this pull request

Add ngram_range(1, 2) - unigrams and bigrams