### PR TITLE
Delete all old themes for consultation.

### DIFF
--- a/consultation_analyser/pipeline/processing.py
+++ b/consultation_analyser/pipeline/processing.py
@@ -3,6 +3,7 @@ from typing import Optional
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from consultation_analyser.consultations.models import Theme
 from consultation_analyser.hosting_environment import HostingEnvironment
 from consultation_analyser.pipeline.backends.bertopic import BERTopicBackend
 from consultation_analyser.pipeline.backends.dummy_llm_backend import DummyLLMBackend
@@ -44,6 +45,10 @@ def get_llm_backend(llm_identifier: Optional[str] = None):
 
 
 def process_consultation_themes(consultation, topic_backend=None, llm_backend=None):
+    # TODO - remove once we have the concept of processing runs
+    # Delete existing rogue themes so they don't exist in the background
+    Theme.objects.filter(question__section__consultation=consultation).delete()
+
     if not topic_backend:
         topic_backend = BERTopicBackend()
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Delete the existing themes for a consultation before running, otherwise we might have rogue themes floating about. This could be particularly problematic for themes attached to answers with no free text (as now we don't want to give them a theme).

This isn't the cleanest approach. Should be resolved when we move to "processing runs".

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A