### PR TITLE
Feature/Display version tag in deployed environments

### DIFF
--- a/consultation_analyser/consultations/jinja2/base.html
+++ b/consultation_analyser/consultations/jinja2/base.html
@@ -108,7 +108,11 @@
         {
           "href": "/privacy/",
           "text": "Privacy notice"
-        }
+        },
+        {
+          "href": version.url(),
+          "text": version.version_string()
+        },
       ]
     }
   }) }}

--- a/consultation_analyser/context_processors.py
+++ b/consultation_analyser/context_processors.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from django.conf import settings
 from django.http import HttpRequest
 from django.urls import resolve
 from django.urls.exceptions import Resolver404
@@ -11,6 +12,26 @@ class AppConfig:
     path: str
     menu_items: list
     show_provisional_data_warning: bool = False
+
+
+@dataclass
+class Version:
+    sha: str
+
+    def version_string(self):
+        if self.sha:
+            return f"Version: {self.sha[:8]}"
+        else:
+            # Jinja2 will not print this, which is what we want
+            return ""
+
+    def url(self):
+        if self.sha:
+            return f"https://github.com/i-dot-ai/consultation-analyser/commit/{self.sha}"
+
+
+def version(request: HttpRequest):
+    return {"version": Version(sha=settings.GIT_SHA)}
 
 
 def app_config(request: HttpRequest):

--- a/consultation_analyser/settings/base.py
+++ b/consultation_analyser/settings/base.py
@@ -79,6 +79,7 @@ TEMPLATES = [
             "environment": "consultation_analyser.jinja2.environment",
             "context_processors": [
                 "consultation_analyser.context_processors.app_config",
+                "consultation_analyser.context_processors.version",
                 "django.contrib.messages.context_processors.messages",
             ],
         },
@@ -209,3 +210,6 @@ BERTOPIC_DEFAULT_EMBEDDING_MODEL = "thenlper/gte-small"
 
 # Authentication
 LOGIN_URL = "/sign-in/"
+
+# version info
+GIT_SHA = env("GIT_SHA", default=None)

--- a/tests/integration/test_git_version.py
+++ b/tests/integration/test_git_version.py
@@ -1,0 +1,16 @@
+import pytest
+from django.test import override_settings
+
+
+@pytest.mark.django_db
+@override_settings(GIT_SHA="12345678abcdefghijklmnoprstuvwxyz")  # pragma: allowlist secret
+def test_git_version_displayed_from_env(django_app):
+    homepage = django_app.get("/")
+    assert "Version: 12345678" in homepage
+
+
+@pytest.mark.django_db
+@override_settings(GIT_SHA=None)
+def test_default_to_local(django_app):
+    homepage = django_app.get("/")
+    assert "Version:" not in homepage


### PR DESCRIPTION
## Context

Building on #250 but moves the link to the bottom of the page and makes it part of the footer

## Changes proposed in this pull request

This link will appear when GIT_SHA is set in the env (which it [now is](https://github.com/i-dot-ai/consultation-analyser/blob/main/infrastructure/ecs.tf#L16) for all deployed envs)

<img width="1030" alt="Screenshot 2024-06-25 at 11 59 01" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/941da9d6-fc99-4045-86de-104ac585e510">

The destination of the link will be that commit in this repo. (GitHub provides a link to the last merged PR from that page, so it's a good jumping-off point).

Intended behaviour is that this is not displayed locally, as we can get that information in other ways locally

## Guidance to review

Try setting `GIT_SHA` in `.env` and see it appear.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo