### PR TITLE
Bugfix/Only one user could be added to a consultation at a time

### DIFF
--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -43,7 +43,9 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
 
     highest_theme_count = filtered_themes.aggregate(Max("answer_count"))["answer_count__max"]
 
-    blank_free_text_count = models.Answer.objects.filter(question=question).filter(free_text="").count()
+    blank_free_text_count = (
+        models.Answer.objects.filter(question=question).filter(free_text="").count()
+    )
 
     context = {
         "consultation_slug": consultation_slug,

--- a/consultation_analyser/support_console/views/consultations_users.py
+++ b/consultation_analyser/support_console/views/consultations_users.py
@@ -23,10 +23,10 @@ def new(request: HttpRequest, consultation_id: UUID):
             users = form.cleaned_data["users"]
             for user in users:
                 consultation.users.add(user)
-                messages.success(request, "Users updated")
-                return redirect(
-                    reverse("support_consultation", kwargs={"consultation_id": consultation.id})
-                )
+            messages.success(request, "Users updated")
+            return redirect(
+                reverse("support_consultation", kwargs={"consultation_id": consultation.id})
+            )
     else:
         form = AddUsersToConsultationForm(users=users, consultation=consultation)
 

--- a/tests/integration/test_managing_consultation_users_via_support.py
+++ b/tests/integration/test_managing_consultation_users_via_support.py
@@ -1,0 +1,33 @@
+import pytest
+
+from consultation_analyser.consultations.models import Consultation
+from consultation_analyser.factories import UserFactory
+from tests.helpers import sign_in
+
+
+@pytest.mark.django_db
+def test_managing_consultation_users_via_support(django_app):
+    # given I am an admin user
+    user = UserFactory(email="email@example.com", is_staff=True)
+    user2 = UserFactory(email="email2222@example.com", is_staff=False)
+    user3 = UserFactory(email="email3333@example.com", is_staff=False)
+
+    sign_in(django_app, user.email)
+
+    # when I generate a dummy consultation
+    consultations_page = django_app.get("/support/consultations/")
+    consultations_page = consultations_page.form.submit("generate_dummy_consultation")
+
+    latest_consultation = Consultation.objects.all().order_by("created_at").last()
+    consultation_page = consultations_page.click(latest_consultation.name)
+
+    assert "email2222@example.com" not in consultation_page
+
+    consultation_users_page = consultation_page.click("Add users")
+    consultation_users_page.form["users"] = [user2.id, user3.id]
+
+    consultation_page = consultation_users_page.form.submit().follow()
+
+    assert "Users updated" in consultation_page
+    assert "email2222@example.com" in consultation_page
+    assert "email3333@example.com" in consultation_page


### PR DESCRIPTION
## Context

It was only possible to add one user to a consultation at a time

## Changes proposed in this pull request

Add a test & fix the bug.

## Guidance to review

Fix should make sense

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-302

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo