### PR TITLE
Bugfix/Do not send unhandled errors to Sentry

### DIFF
--- a/consultation_analyser/settings/production.py
+++ b/consultation_analyser/settings/production.py
@@ -8,10 +8,43 @@ SENTRY_DSN = env("SENTRY_DSN")  # noqa: F405
 EXECUTION_CONTEXT = env("EXECUTION_CONTEXT")  # noqa: F405
 GIT_SHA = env("GIT_SHA")  # noqa: F405
 
+
+def sentry_before_send(event, hint):
+    """Filters Sentry events before sending.
+
+    Adapted from https://jkfran.com/capturing-unhandled-exceptions-sentry-python/
+
+    This function filters out handled exceptions.
+
+    Args:
+        event (dict): The event dictionary containing exception data.
+
+        hint (dict): Additional information about the event, including
+            the original exception.
+
+    Returns:
+        dict: The modified event dictionary, or None if the event should be
+            ignored.
+    """
+    # Ignore handled exceptions
+    exceptions = event.get("exception", {}).get("values", [])
+    if exceptions:
+        exc = exceptions[-1]
+        mechanism = exc.get("mechanism")
+
+        if mechanism:
+            if mechanism.get("handled"):
+                return None
+
+    return event
+
+
 sentry_sdk.init(
     dsn=SENTRY_DSN,
     environment=ENVIRONMENT,  # noqa: F405
     release=GIT_SHA,
+    before_send=sentry_before_send,
 )
+
 
 sentry_sdk.set_tags({"execution_context": EXECUTION_CONTEXT})


### PR DESCRIPTION
## Context

We get a lot of Sentry errors due to the way the langchain/pydantic `OutputParser` works, by repeatedly throwing and catching exceptions until something parses correctly.

<img width="1188" alt="errors" src="https://github.com/i-dot-ai/consultation-analyser/assets/642279/ac4fb4d7-79f2-4873-8045-56260c599185">

By default Sentry reports even handled exceptions, but these exceptions aren't interesting to us because they're part of normal execution in a third-party library.

This PR attempts to silence them following [this approach](https://jkfran.com/capturing-unhandled-exceptions-sentry-python/)

## Changes proposed in this pull request

Add the suggested code

## Guidance to review

**DRAFT as currently testing on dev!**

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/jira/software/projects/CON/boards/418?selectedIssue=CON-285

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo