### PR TITLE
Bugfix/Do not bail if --clean is passed and no consultation exists

### DIFF
--- a/consultation_analyser/consultations/management/commands/generate_themes.py
+++ b/consultation_analyser/consultations/management/commands/generate_themes.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
 
@@ -81,9 +82,12 @@ class Command(BaseCommand):
         if clean:
             input_json = json.loads(open(input_file).read())
             name = input_json["consultation"]["name"]
-            old_consultation = models.Consultation.objects.get(name=name)
-            old_consultation.delete()
-            logger.info("Removed original consultation")
+            try:
+                old_consultation = models.Consultation.objects.get(name=name)
+                old_consultation.delete()
+                logger.info("Removed original consultation")
+            except ObjectDoesNotExist:
+                logger.info("No existing consultation to clean, moving on")
 
         try:
             user = User.objects.filter(email="email@example.com").first()

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -43,7 +43,9 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
 
     highest_theme_count = filtered_themes.aggregate(Max("answer_count"))["answer_count__max"]
 
-    blank_free_text_count = models.Answer.objects.filter(question=question).filter(free_text="").count()
+    blank_free_text_count = (
+        models.Answer.objects.filter(question=question).filter(free_text="").count()
+    )
 
     context = {
         "consultation_slug": consultation_slug,

--- a/tests/commands/test_local_generate_themes.py
+++ b/tests/commands/test_local_generate_themes.py
@@ -9,7 +9,7 @@ from consultation_analyser.factories import UserFactory
 
 
 @pytest.mark.django_db
-def test_local_eval(tmp_path):
+def test_local_generate_themes(tmp_path):
     UserFactory(email="email@example.com")
 
     file_path = settings.BASE_DIR / "tests" / "examples" / "chocolate.json"
@@ -22,3 +22,18 @@ def test_local_eval(tmp_path):
 
     # Bail if it's invalid
     ConsultationWithResponsesAndThemes(**with_themes)
+
+
+@pytest.mark.django_db
+def test_generate_themes_clean(tmp_path):
+    UserFactory(email="email@example.com")
+
+    file_path = settings.BASE_DIR / "tests" / "examples" / "chocolate.json"
+
+    # should not throw
+    call_command(
+        "generate_themes", input=file_path, embedding_model="fake", clean=True, output_dir=tmp_path
+    )
+
+    # we're OK if we make it this far
+    assert True


### PR DESCRIPTION
## Context

The `generate_themes` command threw an exception when we passed `--clean` and there was no consultation to clean.

As this can't be a destructive action, swallow the exception and log a line that we're not cleaning anything, for information.

## Changes proposed in this pull request

See commit

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo