### PR TITLE
EN-248 - refactor: use new ecs module policy syntax

### DIFF
--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -25,6 +25,8 @@ locals {
     "BATCH_JOB_DEFINITION" = module.batch_job_definition.job_definition_name,
     "EXECUTION_CONTEXT"    = "ecs"
   })
+
+  additional_policy_arns = {for idx, arn in [aws_iam_policy.ecs.arn] : idx => arn}
 }
 
 module "ecs" {
@@ -54,7 +56,7 @@ module "ecs" {
   route53_record_name          = aws_route53_record.type_a_record.name
   ip_whitelist                 = var.external_ips
   create_listener              = true
-  task_additional_iam_policy   = aws_iam_policy.ecs.arn
+  task_additional_iam_policies = local.additional_policy_arns
   additional_execution_role_tags = {
     "RolePassableByRunner" = "True"
   }


### PR DESCRIPTION
## Context

Updating terraform to use new ecs module policy attachment syntax.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

https://technologyprogramme.atlassian.net/browse/EN-246

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo