### PR TITLE
Hide multiple-choice question title if it matches overall question title

### DIFF
--- a/consultation_analyser/consultations/jinja2/consultations/questions/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/show.html
@@ -21,12 +21,15 @@
     </div>
   </div>
   {% if multiple_choice_questions %}
-    {% for question, responses in multiple_choice_questions.items() %}
+    {% for multiple_choice_question, multiple_choice_responses in multiple_choice_questions.items() %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h3 class="govuk-heading-s">{{ question }}</h3>
+          {# Show multiple-choice question title only if it's not the same as the overall question title #}
+          {% if multiple_choice_question != question.text %}
+            <h2 class="govuk-heading-s">{{ multiple_choice_question }}</h2>
+          {% endif %}
           <dl class="govuk-summary-list">
-            {% for response in responses %}
+            {% for response in multiple_choice_responses %}
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                   {{ response.answer }}
@@ -40,7 +43,7 @@
         </div>
         <div class="govuk-grid-column-one-third govuk-!-padding-0">
           <donut-chart>
-            {% for response in responses %}
+            {% for response in multiple_choice_responses %}
               <chart-item data-label="{{ response.answer }}" data-count="{{ response.percent }}"></chart-item>
             {% endfor %}
           </donut-chart>


### PR DESCRIPTION
## Context

It looks strange, and could potentially be confusing for users, to show the same question title twice.


## Changes proposed in this pull request

* Hide the mutliple-choice question title if it matches the overall question title
* Use a `<h2>` for the multiple-choice question title, where it does appear (rather than a `<h3>`, to tidy-up heading structure)
* Rename `multiple_choice_` variables to prevent confusion with main `question`

### Where the titles are the same:
<img src="https://github.com/i-dot-ai/consultation-analyser/assets/1634605/5184acd9-a02d-43d7-a600-54ba1bca8a71" width="400px" alt="Screenshot showing only one title"/>


### Where the titles are different:
<img src="https://github.com/i-dot-ai/consultation-analyser/assets/1634605/fd0f1f62-2f26-48c0-8b5e-f30f957cb622" width="400px" alt="Screenshot showing two different titles"/>


## Guidance to review

Please check a few question summary pages to check it's working as expected
