### PR TITLE
DRAFT: Add messages in the views instead of in the decorator

### DIFF
--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -1,6 +1,7 @@
 import logging
 import time
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
@@ -12,6 +13,8 @@ from ..forms.consultation_upload_form import ConsultationUploadForm
 from .decorators import user_can_see_consultation
 
 logger = logging.getLogger("django.server")
+
+NO_THEMES_YET_MESSAGE = "We are processing your consultation. Themes have not been generated yet."
 
 
 @login_required
@@ -30,6 +33,9 @@ def show(request: HttpRequest, consultation_slug: str) -> HttpResponse:
     questions = models.Question.objects.filter(section__consultation__slug=consultation_slug)
 
     context = {"questions": questions, "consultation": consultation}
+
+    if not consultation.has_themes():
+        messages.info(request, NO_THEMES_YET_MESSAGE)
 
     return render(request, "consultations/consultations/show.html", context)
 

--- a/consultation_analyser/consultations/views/decorators.py
+++ b/consultation_analyser/consultations/views/decorators.py
@@ -1,4 +1,3 @@
-from django.contrib import messages
 from django.shortcuts import get_object_or_404
 
 from .. import models
@@ -9,14 +8,12 @@ def user_can_see_consultation(view_function):
         slug = kwargs.get("consultation_slug")
 
         # will kick out users by throwing a 404 if they don't own the consultation
-        consultation = get_object_or_404(
-            models.Consultation.objects.filter(slug=slug, users__in=[request.user])
-        )
+        get_object_or_404(models.Consultation.objects.filter(slug=slug, users__in=[request.user]))
 
-        if not consultation.has_themes():
-            messages.info(
-                request, "We are processing your consultation. Themes have not been generated yet."
-            )
+        # if not consultation.has_themes():
+        #     messages.info(
+        #         request, "We are processing your consultation. Themes have not been generated yet."
+        #     )
 
         return view_function(request, *args, **kwargs)
 

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -1,9 +1,11 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Max
 from django.http import HttpRequest
 from django.shortcuts import render
 
 from .. import models
+from .consultations import NO_THEMES_YET_MESSAGE
 from .decorators import user_can_see_consultation
 from .filters import get_applied_filters, get_filtered_responses, get_filtered_themes
 
@@ -16,6 +18,10 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
         section__slug=section_slug,
         section__consultation__slug=consultation_slug,
     )
+    consultation = question.section.consultation
+    if not consultation.has_themes():
+        messages.info(request, NO_THEMES_YET_MESSAGE)
+
     applied_filters = get_applied_filters(request)
     responses = get_filtered_responses(question, applied_filters)
     filtered_themes = (

--- a/consultation_analyser/consultations/views/responses.py
+++ b/consultation_analyser/consultations/views/responses.py
@@ -1,9 +1,11 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.http import HttpRequest
 from django.shortcuts import render
 
 from .. import models
+from .consultations import NO_THEMES_YET_MESSAGE
 from .decorators import user_can_see_consultation
 from .filters import get_applied_filters, get_filtered_responses
 
@@ -16,6 +18,11 @@ def index(request: HttpRequest, consultation_slug: str, section_slug: str, quest
         section__slug=section_slug,
         section__consultation__slug=consultation_slug,
     )
+
+    consultation = question.section.consultation
+    if not consultation.has_themes():
+        messages.info(request, NO_THEMES_YET_MESSAGE)
+
     themes_for_question = models.Theme.objects.filter(answer__question=question).distinct()
     total_responses = models.Answer.objects.filter(question=question).count()
     applied_filters = get_applied_filters(request)

--- a/consultation_analyser/pipeline/backends/bertopic.py
+++ b/consultation_analyser/pipeline/backends/bertopic.py
@@ -58,9 +58,7 @@ class BERTopicBackend(TopicBackend):
         logger.info("BERTopic topic model generation")
         self.topic_model = self.__get_topic_model(answers_list_with_embeddings)
 
-        answers_topics_df = self.__get_answers_and_topics(
-            self.topic_model, answers_list
-        )
+        answers_topics_df = self.__get_answers_and_topics(self.topic_model, answers_list)
 
         assignments = []
         for row in answers_topics_df.itertuples():


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
It doesn't make sense for this check to be in the decorator, just add the message in the views (there are only 3 relevant views).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [ ] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo