### PR TITLE
Feature/messages views

### DIFF
--- a/consultation_analyser/consultations/views/consultations.py
+++ b/consultation_analyser/consultations/views/consultations.py
@@ -1,6 +1,7 @@
 import logging
 import time
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
@@ -12,6 +13,9 @@ from ..forms.consultation_upload_form import ConsultationUploadForm
 from .decorators import user_can_see_consultation
 
 logger = logging.getLogger("django.server")
+
+
+NO_THEMES_YET_MESSAGE = "We are processing your consultation. Themes have not been generated yet."
 
 
 @login_required
@@ -28,8 +32,10 @@ def index(request: HttpRequest) -> HttpResponse:
 def show(request: HttpRequest, consultation_slug: str) -> HttpResponse:
     consultation = get_object_or_404(models.Consultation, slug=consultation_slug)
     questions = models.Question.objects.filter(section__consultation__slug=consultation_slug)
-
     context = {"questions": questions, "consultation": consultation}
+
+    if not consultation.has_processing_run():
+        messages.info(request, NO_THEMES_YET_MESSAGE)
 
     return render(request, "consultations/consultations/show.html", context)
 

--- a/consultation_analyser/consultations/views/decorators.py
+++ b/consultation_analyser/consultations/views/decorators.py
@@ -1,4 +1,3 @@
-from django.contrib import messages
 from django.shortcuts import get_object_or_404
 
 from .. import models
@@ -9,14 +8,7 @@ def user_can_see_consultation(view_function):
         slug = kwargs.get("consultation_slug")
 
         # will kick out users by throwing a 404 if they don't own the consultation
-        consultation = get_object_or_404(
-            models.Consultation.objects.filter(slug=slug, users__in=[request.user])
-        )
-
-        if not consultation.has_processing_run():
-            messages.info(
-                request, "We are processing your consultation. Themes have not been generated yet."
-            )
+        get_object_or_404(models.Consultation.objects.filter(slug=slug, users__in=[request.user]))
 
         return view_function(request, *args, **kwargs)
 

--- a/consultation_analyser/consultations/views/questions.py
+++ b/consultation_analyser/consultations/views/questions.py
@@ -1,9 +1,11 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Max
 from django.http import HttpRequest
 from django.shortcuts import render
 
 from .. import models
+from .consultations import NO_THEMES_YET_MESSAGE
 from .decorators import user_can_see_consultation
 from .filters import get_applied_filters, get_filtered_responses, get_filtered_themes
 
@@ -16,7 +18,11 @@ def show(request: HttpRequest, consultation_slug: str, section_slug: str, questi
         section__slug=section_slug,
         section__consultation__slug=consultation_slug,
     )
+
     consultation = question.section.consultation
+    if not consultation.has_processing_run():
+        messages.info(request, NO_THEMES_YET_MESSAGE)
+
     # TODO - for now default to latest processing run
     processing_run = consultation.latest_processing_run
 

--- a/consultation_analyser/consultations/views/responses.py
+++ b/consultation_analyser/consultations/views/responses.py
@@ -1,9 +1,11 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.http import HttpRequest
 from django.shortcuts import render
 
 from .. import models
+from .consultations import NO_THEMES_YET_MESSAGE
 from .decorators import user_can_see_consultation
 from .filters import get_applied_filters, get_filtered_responses
 
@@ -17,6 +19,9 @@ def index(request: HttpRequest, consultation_slug: str, section_slug: str, quest
         section__consultation__slug=consultation_slug,
     )
     consultation = question.section.consultation
+    if not consultation.has_processing_run():
+        messages.info(request, NO_THEMES_YET_MESSAGE)
+
     # TODO - for now, get themes from latest processing run
     latest_processing_run = consultation.latest_processing_run
     if latest_processing_run:

--- a/tests/views/test_consultation_scoping.py
+++ b/tests/views/test_consultation_scoping.py
@@ -5,19 +5,18 @@ from django.test import RequestFactory
 from consultation_analyser.consultations.views import consultations
 from consultation_analyser.factories import ConsultationFactory, UserFactory
 
-# TODO - fix for messages
-# @pytest.mark.django_db
-# def test_get_consultation_we_own():
-#     user = UserFactory()
-#     consultation_we_own = ConsultationFactory(user=user, with_themes=True)
 
-#     request_factory = RequestFactory()
+@pytest.mark.django_db
+def test_get_consultation_we_own():
+    user = UserFactory()
+    consultation_we_own = ConsultationFactory(user=user, with_themes=True)
 
-#     valid_request = request_factory.get("/consultations/slug-does-not-matter-here/")
-#     valid_request.user = user
-#     resp = consultations.show(valid_request, consultation_slug=consultation_we_own.slug)
+    request_factory = RequestFactory()
+    valid_request = request_factory.get("/consultations/slug-does-not-matter-here/")
+    valid_request.user = user
 
-#     assert resp.status_code == 200
+    resp = consultations.show(valid_request, consultation_slug=consultation_we_own.slug)
+    assert resp.status_code == 200
 
 
 @pytest.mark.django_db

--- a/tests/views/test_consultation_scoping.py
+++ b/tests/views/test_consultation_scoping.py
@@ -7,16 +7,12 @@ from consultation_analyser.factories import ConsultationFactory, UserFactory
 
 
 @pytest.mark.django_db
-def test_get_consultation_we_own():
+def test_get_consultation_we_own(client):
     user = UserFactory()
     consultation_we_own = ConsultationFactory(user=user, with_themes=True)
-
-    request_factory = RequestFactory()
-    valid_request = request_factory.get("/consultations/slug-does-not-matter-here/")
-    valid_request.user = user
-
-    resp = consultations.show(valid_request, consultation_slug=consultation_we_own.slug)
-    assert resp.status_code == 200
+    client.force_login(user)
+    response = client.get(f"/consultations/{consultation_we_own.slug}/")
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
The messages don't belong in the decorator - just explicitly add them in the required views (only the 3 views a standard user sees for viewing consultation).

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- Move messages for no themes to the views
- Uncomment test - make changes as RequestFactory fails with an error on messages as it does not support middleware (https://docs.djangoproject.com/en/5.0/topics/testing/advanced/#django.test.RequestFactory)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Shouldn't actually change what users see. If you create a new dummy consultation in the app, viewing pages in the frontend should give you the same message about themes not being generated yet.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo - N/A