### PR TITLE
Allow users to generate llm summaries separately.

### DIFF
--- a/consultation_analyser/consultations/management/commands/run_llm_summariser.py
+++ b/consultation_analyser/consultations/management/commands/run_llm_summariser.py
@@ -1,0 +1,26 @@
+from django.core.management.base import BaseCommand
+
+from consultation_analyser.consultations import models
+from consultation_analyser.pipeline.processing import summarise_with_llm
+
+
+class Command(BaseCommand):
+    help = "Run the LLM summariser to generate improved summaries for themes."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--consultation_slug", action="store", help="The slug for the consultation", type=str
+        )
+
+    def handle(self, *args, **options):
+        if options["consultation_slug"]:
+            try:
+                consultation = models.Consultation.objects.get(slug=options["consultation_slug"])
+                summarise_with_llm(consultation)
+                self.stdout.write(
+                    f"LLM summariser has been run for consultation with name {consultation.name}"
+                )
+            except models.Consultation.DoesNotExist:
+                self.stdout.write("You need to enter a valid slug for a consultation")
+        else:
+            self.stdout.write("You need to enter the slug for a consultation")

--- a/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
+++ b/consultation_analyser/support_console/jinja2/support_console/consultations/show.html
@@ -78,12 +78,16 @@
         <h2 class="govuk-heading-m">Generate themes</h2>
         <div>
           <p class="govuk-body">
-            Generating themes runs topic modelling then LLM summarisation.
+            Generating themes runs topic modelling then LLM summarisation. You may re-run the theme summarisation for the lastest run separately.
           </p>
         </div>
         {{ govukButton({
           'text': "Generate themes",
           'name': "generate_themes"
+        }) }}
+        {{ govukButton({
+          'text': "Summarise themes",
+          'name': "llm_summarisation"
         }) }}
 
         <h2 class="govuk-heading-m">Download JSON</h2>

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -66,13 +66,13 @@ def show(request: HttpRequest, consultation_id: UUID) -> HttpResponse:
             run_processing_pipeline(consultation)
             messages.success(request, "Consultation data has been sent for processing")
         elif "llm_summarisation" in request.POST:
-            try:
+            if not consultation.latest_processing_run:
+                messages.error(request, "Cannot run LLM summarisation as no topics created")
+            else:
                 run_llm_summariser(consultation)
                 messages.success(
                     request, "(Re-)running LLM summarisation on the latest processing run"
                 )
-            except models.ProcessingRun.DoesNotExist:
-                messages.error(request, "Cannot run LLM summarisation as no topics created")
         elif "download_json" in request.POST:
             consultation_json = consultation_to_json(consultation)
             response = HttpResponse(consultation_json, content_type="application/json")


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Making the change so that we can run the LLM step separately.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- At the moment have just added a button to generate LLM separately, but the general button does topic model + LLM.
- Do we need another button to do topic modelling on its own? (Can do in a separate PR?)

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo