### PR TITLE
Refactor/factories and dummy data

### DIFF
--- a/consultation_analyser/consultations/dummy_data.py
+++ b/consultation_analyser/consultations/dummy_data.py
@@ -2,20 +2,13 @@ import datetime
 import random
 
 from consultation_analyser.factories import (
-    AnswerFactory,
-    ConsultationFactory,
-    ConsultationResponseFactory,
+    ConsultationBuilder,
     FakeConsultationData,
-    ProcessingRunFactory,
-    QuestionFactory,
-    SectionFactory,
-    ThemeFactory,
-    TopicModelMetadataFactory,
 )
 from consultation_analyser.hosting_environment import HostingEnvironment
 
 
-def create_dummy_data(responses=10, include_themes=True, number_questions=10, **options):
+def create_dummy_data(responses=10, number_questions=10, **options):
     if number_questions > 10:
         raise RuntimeError("You can't have more than 10 questions")
     if HostingEnvironment.is_production():
@@ -28,77 +21,39 @@ def create_dummy_data(responses=10, include_themes=True, number_questions=10, **
     if "slug" not in options:
         options["slug"] = f"consultation-slug-{timestamp}"
 
-    consultation = ConsultationFactory(**options)
-    section = SectionFactory(name="Base section", consultation=consultation)
+    consultation_builder = ConsultationBuilder(**options)
     fake_consultation_data = FakeConsultationData()
     all_questions = fake_consultation_data.all_questions()
     questions_to_include = all_questions[:number_questions]
 
     questions = [
-        QuestionFactory(
+        consultation_builder.add_question(
             text=q["text"],
             slug=q["slug"],
             multiple_choice_questions=[
                 (x["question_text"], x["options"]) for x in (q.get("multiple_choice") or [])
             ],
             has_free_text=q["has_free_text"],
-            section=section,
         )
         for q in questions_to_include
     ]
-    for r in range(responses):
-        response = ConsultationResponseFactory(consultation=consultation)
-        answers = []
+
+    for i, r in enumerate(range(responses)):
         for q in questions:
             if q.has_free_text:
-                free_text_answer = fake_consultation_data.get_free_text_answer(q.slug)
-                answers.append(
-                    AnswerFactory(
-                        question=q,
-                        consultation_response=response,
-                        free_text=free_text_answer,
-                    )
-                )
-                # Force some answers to have no free text response
                 if random.randrange(1, 4) == 1:
-                    ans = AnswerFactory(
-                        question=q,
-                        consultation_response=response,
-                        free_text="",
-                    )
-                    ans.themes.clear()
-                    answers.append(ans)
+                    free_text_answer = ""
+                else:
+                    free_text_answer = fake_consultation_data.get_free_text_answer(q.slug)
             else:
-                ans = AnswerFactory(question=q, consultation_response=response)
-                ans.themes.clear()
-                answers.append(ans)
+                free_text_answer = None
 
-        # cause the last question to have answers with two responses to the multiple choice
-        # so that we always have a path to test this through the frontend
-        q = questions[-1]
-        question_mc = q.multiple_choice_options[0]
-        possibles = question_mc["options"].copy()
-        for a in q.answer_set.all():
-            answer_mc = a.multiple_choice[0]
-            random.shuffle(possibles)
-            answer_mc["options"] = possibles[:2]
-            a.multiple_choice = [answer_mc]
-            a.save()
+            consultation_builder.add_answer(q, free_text=free_text_answer)
+            consultation_builder.next_response()
 
-        if include_themes:
-            # Set themes per question, multiple answers with the same theme
-            processing_run = ProcessingRunFactory(consultation=consultation)
-            for q in questions:
-                tm = TopicModelMetadataFactory()
-                themes = [
-                    ThemeFactory(topic_model_metadata=tm, topic_id=i, processing_run=processing_run)
-                    for i in range(-1, 4)
-                ]
-                for a in answers[1:]:
-                    random_theme = random.choice(themes)
-                    a.themes.add(random_theme)
-                    a.save()
-            # Force at least one answer to be an outlier
-            answers[0].themes.add(themes[0])
-            answers[0].save()
-    return consultation
+    # always assign a double multichoice selection to the last question
+    question_options = q.multiple_choice_options[0]
+    answers = (question_options["question_text"], question_options["options"][:2])
+    consultation_builder.add_answer(q, multiple_choice_answers=[answers])
+
+    return consultation_builder.consultation

--- a/consultation_analyser/consultations/jinja2/consultations/questions/show.html
+++ b/consultation_analyser/consultations/jinja2/consultations/questions/show.html
@@ -50,7 +50,7 @@
           {% if not multiple_choice.has_multiple_selections %}
             <donut-chart>
               {% for option in multiple_choice.counts.keys() %}
-                <chart-item data-label="{{ option }}" data-count="{{ multiple_choice.percentages[option] }}"></chart-item>
+                <chart-item data-label="{{ option }}" data-count="{{ multiple_choice.percentages()[option] }}"></chart-item>
               {% endfor %}
             </donut-chart>
           {% endif %}

--- a/consultation_analyser/consultations/models.py
+++ b/consultation_analyser/consultations/models.py
@@ -98,7 +98,6 @@ class MultipleChoiceQuestionStats:
                 "It does not make sense to calculate percentages for a multiple choice question supporting multiple selections"
             )
         else:
-            print(self.counts)
             return {
                 option: round((float(count) / self.total_responses) * 100)
                 for option, count in self.counts.items()

--- a/consultation_analyser/factories.py
+++ b/consultation_analyser/factories.py
@@ -39,9 +39,8 @@ class FakeConsultationData:
 
 
 class ConsultationBuilder:
-    def __init__(self, consultation=None):
-        if not consultation:
-            consultation = ConsultationFactory()
+    def __init__(self, **kwargs):
+        consultation = ConsultationFactory(**kwargs)
 
         self.consultation = consultation
         self.current_response = None

--- a/consultation_analyser/pipeline/backends/dummy_topic_backend.py
+++ b/consultation_analyser/pipeline/backends/dummy_topic_backend.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import random
 

--- a/consultation_analyser/pipeline/backends/dummy_topic_backend.py
+++ b/consultation_analyser/pipeline/backends/dummy_topic_backend.py
@@ -1,4 +1,6 @@
+import functools
 import logging
+import random
 
 from faker import Faker
 
@@ -7,7 +9,23 @@ from consultation_analyser.consultations import models
 from .topic_backend import TopicBackend
 from .types import TopicAssignment
 
-logger = logging.getLogger("django.server")
+logger = logging.getLogger("pipeline")
+
+
+def random_partition(lst):
+    result = []
+    current_sublist = []
+
+    for item in lst:
+        if current_sublist and random.random() < 0.25:
+            result.append(current_sublist)
+            current_sublist = []
+        current_sublist.append(item)
+
+    if current_sublist:
+        result.append(current_sublist)
+
+    return result
 
 
 class DummyTopicBackend(TopicBackend):
@@ -17,11 +35,15 @@ class DummyTopicBackend(TopicBackend):
 
         assignments = []
         topic_id = -1
-        for answer in answers:
+
+        # introduce some clumping in the topics
+        for answer_set in random_partition(answers):
             topic_keywords = faker.words(4)
-            assignments.append(
-                TopicAssignment(topic_id=topic_id, topic_keywords=topic_keywords, answer=answer)
-            )
+            for answer in answer_set:
+                assignments.append(
+                    TopicAssignment(topic_id=topic_id, topic_keywords=topic_keywords, answer=answer)
+                )
+
             topic_id += 1
 
         return assignments

--- a/consultation_analyser/pipeline/processing.py
+++ b/consultation_analyser/pipeline/processing.py
@@ -58,6 +58,8 @@ def process_consultation_themes(consultation, topic_backend=None, llm_backend=No
     save_themes_for_processing_run(topic_backend, processing_run)
     create_llm_summaries_for_processing_run(llm_backend, processing_run)
 
+    return processing_run
+
 
 def run_processing_pipeline(consultation):
     if HostingEnvironment.is_deployed():

--- a/consultation_analyser/support_console/views/consultations.py
+++ b/consultation_analyser/support_console/views/consultations.py
@@ -19,7 +19,7 @@ from consultation_analyser.pipeline.processing import run_processing_pipeline
 def index(request: HttpRequest) -> HttpResponse:
     if request.POST:
         try:
-            consultation = create_dummy_data(include_themes=False, number_questions=10)
+            consultation = create_dummy_data()
             user = request.user
             consultation.users.add(user)
             messages.success(request, "A dummy consultation has been generated")

--- a/tests/commands/test_dummy_data.py
+++ b/tests/commands/test_dummy_data.py
@@ -21,8 +21,6 @@ def test_name_parameter_sets_consultation_name(mock_is_local):
     assert models.Question.objects.count() == 10
     assert models.Answer.objects.count() >= 100
 
-    assert models.Theme.objects.filter(is_outlier=True).exists()
-
     assert models.Consultation.objects.first().name == "My special consultation"
     assert models.Consultation.objects.first().slug == "my-special-consultation"
 

--- a/tests/integration/test_banner.py
+++ b/tests/integration/test_banner.py
@@ -12,6 +12,5 @@ def test_user_can_sign_in(django_app):
     assert "pilot stage" not in logged_out_homepage
 
     consultations_index = sign_in(django_app, "email@example.com")
-    print(consultations_index)
 
     assert "pilot stage" in consultations_index

--- a/tests/integration/test_consultation_page.py
+++ b/tests/integration/test_consultation_page.py
@@ -1,13 +1,13 @@
 import pytest
 
-from consultation_analyser.factories import ConsultationFactory, UserFactory
+from consultation_analyser.factories import ConsultationWithAnswersFactory, UserFactory
 from tests.helpers import sign_in
 
 
 @pytest.mark.django_db
 def test_consultation_page(django_app):
     user = UserFactory()
-    consultation = ConsultationFactory(with_question=True, user=user)
+    consultation = ConsultationWithAnswersFactory(users=(user))
 
     sign_in(django_app, user.email)
 

--- a/tests/integration/test_llm_summariser.py
+++ b/tests/integration/test_llm_summariser.py
@@ -7,19 +7,16 @@ from consultation_analyser.pipeline.llm_summariser import create_llm_summaries_f
 
 @pytest.mark.django_db
 def test_create_llm_summaries_for_consultation():
-    consultation = factories.ConsultationFactory(name="My new consultation")
-    response = factories.ConsultationResponseFactory(consultation=consultation)
-    section = factories.SectionFactory(consultation=consultation)
-    question = factories.QuestionFactory(section=section, has_free_text=True)
-    processing_run = factories.ProcessingRunFactory(consultation=consultation)
-    theme = factories.ThemeFactory(short_description="", summary="", processing_run=processing_run)
-    answer = factories.AnswerFactory(question=question, consultation_response=response)
+    consultation_builder = factories.ConsultationBuilder()
+    theme = consultation_builder.add_theme(summary="", short_description="")
+    question = consultation_builder.add_question()
+    answer = consultation_builder.add_answer(question)
     answer.themes.add(theme)
 
     assert not theme.summary
     assert not theme.short_description
 
-    create_llm_summaries_for_processing_run(DummyLLMBackend(), processing_run)
+    create_llm_summaries_for_processing_run(DummyLLMBackend(), consultation_builder.current_processing_run)
 
     theme.refresh_from_db()
     assert theme.summary

--- a/tests/integration/test_llm_summariser.py
+++ b/tests/integration/test_llm_summariser.py
@@ -16,7 +16,9 @@ def test_create_llm_summaries_for_consultation():
     assert not theme.summary
     assert not theme.short_description
 
-    create_llm_summaries_for_processing_run(DummyLLMBackend(), consultation_builder.current_processing_run)
+    create_llm_summaries_for_processing_run(
+        DummyLLMBackend(), consultation_builder.current_processing_run
+    )
 
     theme.refresh_from_db()
     assert theme.summary

--- a/tests/integration/test_ml_pipeline.py
+++ b/tests/integration/test_ml_pipeline.py
@@ -3,7 +3,6 @@ import pytest
 from consultation_analyser import factories
 from consultation_analyser.consultations import models
 from consultation_analyser.pipeline.backends.bertopic import BERTopicBackend
-from consultation_analyser.pipeline.backends.dummy_topic_backend import DummyTopicBackend
 from consultation_analyser.pipeline.ml_pipeline import (
     save_themes_for_processing_run,
 )
@@ -11,58 +10,25 @@ from consultation_analyser.pipeline.ml_pipeline import (
 
 @pytest.mark.django_db
 def test_topic_model_end_to_end(tmp_path):
-    consultation = factories.ConsultationFactory(name="My new consultation")
-    section = factories.SectionFactory(name="Base section", consultation=consultation)
-    q = factories.QuestionFactory(has_free_text=True, text="Do you like wolves?", section=section)
+    consultation_builder = factories.ConsultationBuilder()
+    question_free_text = consultation_builder.add_question(text="Do you like wolves?")
+    question_no_free_text = consultation_builder.add_question(
+        text="No free text here", has_free_text=False
+    )
 
     # identical answers
     for r in range(10):
-        response = factories.ConsultationResponseFactory(consultation=consultation, answers=False)
-        factories.AnswerFactory(
-            question=q,
-            consultation_response=response,
-            free_text="I love wolves, they are fluffy and cute",
+        consultation_builder.add_answer(
+            question_free_text, free_text="I love wolves, they are fluffy and cute"
         )
+        consultation_builder.add_answer(question_no_free_text)
+        consultation_builder.next_response()
 
     backend = BERTopicBackend()
-    processing_run = factories.ProcessingRunFactory(consultation=consultation)
+    processing_run = factories.ProcessingRunFactory(consultation=consultation_builder.consultation)
     save_themes_for_processing_run(backend, processing_run)
 
     # all answers should get the same theme
     assert models.Theme.objects.count() == 1
 
-
-@pytest.mark.django_db
-def test_save_themes_for_processing_run():
-    consultation = factories.ConsultationFactory(name="My new consultation")
-    section = factories.SectionFactory(name="Base section", consultation=consultation)
-    free_text_question1 = factories.QuestionFactory(
-        section=section, has_free_text=True, slug="mars-bar-recipe-change"
-    )
-    free_text_question2 = factories.QuestionFactory(
-        section=section, has_free_text=True, slug="is-crunchie-too-sweet"
-    )
-    no_free_text_question = factories.QuestionFactory(
-        section=section, has_free_text=False, slug="favorite-cadbury-chocolate-bar"
-    )
-    questions = [free_text_question1, free_text_question2, no_free_text_question]
-    for r in range(10):
-        response = factories.ConsultationResponseFactory(consultation=consultation)
-        [factories.AnswerFactory(question=q, consultation_response=response) for q in questions]
-
-    processing_run = factories.ProcessingRunFactory(consultation=consultation)
-    assert not models.Theme.objects.filter(processing_run__consultation=consultation).exists()
-
-    save_themes_for_processing_run(DummyTopicBackend(), processing_run)
-
-    # Check we've generated themes for questions with full text responses, and check fields populated
-    for q in [free_text_question1, free_text_question2]:
-        themes_for_q = processing_run.get_themes_for_question(question_id=q.id)
-        assert themes_for_q.exists()
-    example_theme = themes_for_q.first()
-    assert example_theme.topic_keywords
-    # Summary not populated here - done in a separate step
-
-    # Check no themes for question with no free text
-    themes_for_q = models.Theme.objects.filter(answer__question=no_free_text_question)
-    assert not themes_for_q.exists()
+    assert not models.Theme.objects.filter(answer__question=question_no_free_text).exists()

--- a/tests/integration/test_ml_pipeline.py
+++ b/tests/integration/test_ml_pipeline.py
@@ -17,7 +17,7 @@ def test_topic_model_end_to_end(tmp_path):
 
     # identical answers
     for r in range(10):
-        response = factories.ConsultationResponseFactory(consultation=consultation)
+        response = factories.ConsultationResponseFactory(consultation=consultation, answers=False)
         factories.AnswerFactory(
             question=q,
             consultation_response=response,

--- a/tests/integration/test_question_pages.py
+++ b/tests/integration/test_question_pages.py
@@ -3,7 +3,6 @@ import re
 
 import pytest
 
-from consultation_analyser.consultations import models
 from consultation_analyser.factories import (
     ConsultationBuilder,
     UserFactory,
@@ -19,7 +18,7 @@ def test_get_question_summary_page(django_app):
     question = consultation_builder.add_question(
         multiple_choice_questions=[("Do you agree?", ["Yes", "No", "Maybe"])]
     )
-    theme = consultation_builder.add_theme(topic_id=1) # prevent outlier
+    theme = consultation_builder.add_theme(topic_id=1)  # prevent outlier
 
     for a in [
         [("Do you agree?", ["Yes"])],

--- a/tests/integration/test_responses_pages.py
+++ b/tests/integration/test_responses_pages.py
@@ -2,12 +2,9 @@ import html
 
 import pytest
 
+from consultation_analyser.consultations.models import Answer, Question
 from consultation_analyser.factories import (
-    AnswerFactory,
-    ConsultationFactory,
-    ConsultationResponseFactory,
-    ProcessingRunFactory,
-    ThemeFactory,
+    ConsultationWithThemesFactory,
     UserFactory,
 )
 from tests.helpers import sign_in
@@ -18,22 +15,12 @@ def test_get_question_responses_page(django_app):
     user = UserFactory(email="email@example.com")
     sign_in(django_app, "email@example.com")
 
-    consultation = ConsultationFactory(
-        user=user,
-        with_question=True,
-        with_question__with_multiple_choice=True,
-        with_question__with_free_text=True,
-    )
+    consultation = ConsultationWithThemesFactory(users=(user))
 
-    consultation_response = ConsultationResponseFactory(consultation=consultation)
-
-    section = consultation.section_set.first()
-    question = section.question_set.first()
-
-    answer = AnswerFactory(question=question, consultation_response=consultation_response)
-    processing_run = ProcessingRunFactory(consultation=consultation)
-    theme = ThemeFactory(processing_run=processing_run)
-    answer.themes.add(theme)
+    processing_run = consultation.latest_processing_run
+    question = Question.objects.last()
+    section = question.section
+    answer = Answer.objects.filter(question=question).first()
     multiple_choice = answer.multiple_choice[0]
 
     question_responses_url = (

--- a/tests/unit/models/test_answer.py
+++ b/tests/unit/models/test_answer.py
@@ -52,20 +52,17 @@ def test_multiple_choice_validation():
 
 @pytest.mark.django_db
 def test_find_answer_multiple_choice_response():
-    q = factories.QuestionFactory(
+    consultation_builder = factories.ConsultationBuilder()
+    question = consultation_builder.add_question(
         multiple_choice_questions=[("Do you agree?", ["Yes", "No", "Maybe"])]
     )
-    resp = factories.ConsultationResponseFactory(consultation=q.section.consultation)
 
-    factories.AnswerFactory(
-        question=q, consultation_response=resp, multiple_choice_answers=[("Do you agree?", ["Yes"])]
-    )
-    factories.AnswerFactory(
-        question=q, consultation_response=resp, multiple_choice_answers=[("Do you agree?", ["No"])]
-    )
-    factories.AnswerFactory(
-        question=q, consultation_response=resp, multiple_choice_answers=[("Do you agree?", ["No"])]
-    )
+    for a in [
+        [("Do you agree?", ["Yes"])],
+        [("Do you agree?", ["No"])],
+        [("Do you agree?", ["No"])],
+    ]:
+        consultation_builder.add_answer(question, multiple_choice_answers=a)
 
     result = models.Answer.objects.filter_multiple_choice(question="Not a question", answer="Yes")
     assert not result

--- a/tests/unit/models/test_answer.py
+++ b/tests/unit/models/test_answer.py
@@ -11,33 +11,29 @@ from consultation_analyser.consultations import models
 )
 @pytest.mark.django_db
 def test_save_theme_to_answer(input_keywords, topic_id, is_outlier):
-    consultation = factories.ConsultationFactory()
-    consultation_response = factories.ConsultationResponseFactory(consultation=consultation)
-    section = factories.SectionFactory(consultation=consultation)
-    question = factories.QuestionFactory(has_free_text=True, section=section)
-    answer = factories.AnswerFactory(question=question, consultation_response=consultation_response)
+    consultation = factories.ConsultationWithAnswersFactory()
+    answer = models.Answer.objects.last()
     processing_run = factories.ProcessingRunFactory(consultation=consultation)
-    topic_model_meta = factories.TopicModelMetadataFactory()
+    tmm = factories.TopicModelMetadataFactory()
+
     #  Check theme created and saved to answer
     answer.save_theme_to_answer(
         topic_keywords=input_keywords,
         topic_id=topic_id,
         processing_run=processing_run,
-        topic_model_metadata=topic_model_meta,
+        topic_model_metadata=tmm,
     )
     theme = models.Theme.objects.get(topic_keywords=input_keywords)
     assert theme.topic_keywords == input_keywords
     assert theme.is_outlier == is_outlier
-    latest_themes_for_answer = processing_run.get_themes_for_answer(answer_id=answer.id)
-    # At the moment, we only have at most one theme for answer and processing run
-    assert latest_themes_for_answer.last().topic_keywords == input_keywords
-    # Check no duplicate created
+
     answer.save_theme_to_answer(
         topic_keywords=input_keywords,
         topic_id=topic_id,
         processing_run=processing_run,
-        topic_model_metadata=topic_model_meta,
+        topic_model_metadata=tmm,
     )
+
     themes_qs = models.Theme.objects.filter(topic_keywords=input_keywords)
     assert themes_qs.count() == 1
 

--- a/tests/unit/models/test_processing_run.py
+++ b/tests/unit/models/test_processing_run.py
@@ -2,37 +2,22 @@ import pytest
 
 from consultation_analyser import factories
 from consultation_analyser.consultations import models
-
-
-def set_up_consultation():
-    consultation = factories.ConsultationFactory()
-    consultation_response = factories.ConsultationResponseFactory(consultation=consultation)
-    section = factories.SectionFactory(consultation=consultation)
-    question = factories.QuestionFactory(section=section, text="Question 1?")
-    answer = factories.AnswerFactory(
-        question=question, consultation_response=consultation_response, free_text="Answer 1"
-    )
-    for i in range(3):
-        processing_run = factories.ProcessingRunFactory(consultation=consultation)
-        theme = factories.ThemeFactory(
-            processing_run=processing_run, short_description=f"Theme {i}"
-        )
-        answer.themes.add(theme)
-    return consultation
+from consultation_analyser.pipeline.backends.dummy_llm_backend import DummyLLMBackend
+from consultation_analyser.pipeline.backends.dummy_topic_backend import DummyTopicBackend
+from consultation_analyser.pipeline.processing import process_consultation_themes
 
 
 @pytest.mark.django_db
 def test_latest_processing_run():
-    consultation1 = factories.ConsultationFactory()
-    assert not consultation1.latest_processing_run
-    consultation2 = set_up_consultation()
-    answer = models.Answer.objects.get(free_text="Answer 1")
-    question = models.Question.objects.get(text="Question 1?")
-    latest_run = consultation2.latest_processing_run
-    assert latest_run
-    themes = latest_run.get_themes_for_answer(answer.id)
-    assert themes.last().short_description == "Theme 2"
-    assert "Theme 0" not in themes.values_list("short_description", flat=True)
-    themes = latest_run.get_themes_for_question(question.id)
-    assert themes.count() == 1  # Ensure distinct
-    assert themes.last().short_description == "Theme 2"
+    consultation = factories.ConsultationWithAnswersFactory()
+    answer = models.Answer.objects.last()
+
+    run1 = process_consultation_themes(consultation, DummyTopicBackend(), DummyLLMBackend())
+    run2 = process_consultation_themes(consultation, DummyTopicBackend(), DummyLLMBackend())
+
+    latest_theme_for_answer = consultation.latest_processing_run.get_themes_for_answer(
+        answer.id
+    ).last()
+
+    assert latest_theme_for_answer == run2.get_themes_for_answer(answer.id).last()
+    assert latest_theme_for_answer != run1.get_themes_for_answer(answer.id).last()

--- a/tests/unit/models/test_question.py
+++ b/tests/unit/models/test_question.py
@@ -6,10 +6,9 @@ from consultation_analyser.consultations.models import MultipleChoiceNotProporti
 
 @pytest.mark.django_db
 def test_get_multiple_choice_stats():
-    consultation = factories.ConsultationFactory()
-    section = factories.SectionFactory()
-    question = factories.QuestionFactory(
-        section=section, multiple_choice_questions=[("What do you like?", ["Rain", "Sun", "Snow"])]
+    consultation_builder = factories.ConsultationBuilder()
+    question = consultation_builder.add_question(
+        multiple_choice_questions=[("What do you like?", ["Rain", "Sun", "Snow"])]
     )
 
     for a in [
@@ -22,10 +21,8 @@ def test_get_multiple_choice_stats():
         ["Rain", "Sun"],
         ["Sun", "Snow"],
     ]:
-        factories.AnswerFactory(
-            multiple_choice_answers=[("What do you like?", a)],
-            question=question,
-            consultation_response=factories.ConsultationResponseFactory(consultation=consultation),
+        consultation_builder.add_answer(
+            question, multiple_choice_answers=[("What do you like?", a)]
         )
 
     result = question.multiple_choice_stats()
@@ -47,10 +44,9 @@ def test_get_multiple_choice_stats():
 
 @pytest.mark.django_db
 def test_get_multiple_choice_has_multiple_selections():
-    consultation = factories.ConsultationFactory()
-    section = factories.SectionFactory()
-    question = factories.QuestionFactory(
-        section=section, multiple_choice_questions=[("What do you like?", ["Rain", "Sun", "Snow"])]
+    consultation_builder = factories.ConsultationBuilder()
+    question = consultation_builder.add_question(
+        multiple_choice_questions=[("What do you like?", ["Rain", "Sun", "Snow"])]
     )
 
     for a in [
@@ -58,10 +54,8 @@ def test_get_multiple_choice_has_multiple_selections():
         ["Sun"],
         ["Snow"],
     ]:
-        factories.AnswerFactory(
-            multiple_choice_answers=[("What do you like?", a)],
-            question=question,
-            consultation_response=factories.ConsultationResponseFactory(consultation=consultation),
+        consultation_builder.add_answer(
+            question, multiple_choice_answers=[("What do you like?", a)]
         )
 
     result = question.multiple_choice_stats()

--- a/tests/unit/test_delete_consultation.py
+++ b/tests/unit/test_delete_consultation.py
@@ -1,31 +1,19 @@
 import pytest
 
 from consultation_analyser.consultations import models
-from consultation_analyser.factories import (
-    AnswerFactory,
-    ConsultationResponseFactory,
-    ProcessingRunFactory,
-    QuestionFactory,
-    ThemeFactory,
-)
+from consultation_analyser.factories import ConsultationWithThemesFactory
 
 
 @pytest.mark.django_db
 def test_delete_consultation():
-    question = QuestionFactory()
-    consultation = question.section.consultation
-    consultation_response = ConsultationResponseFactory(consultation=consultation)
-    answer = AnswerFactory(question=question, consultation_response=consultation_response)
-    processing_run = ProcessingRunFactory(consultation=consultation)
-    theme = ThemeFactory(processing_run=processing_run)
-    answer.themes.add(theme)
+    consultation = ConsultationWithThemesFactory()
 
     assert models.Consultation.objects.count() == 1
-    assert models.ConsultationResponse.objects.count() == 1
-    assert models.Section.objects.count() == 1
-    assert models.Question.objects.count() == 1
-    assert models.Answer.objects.count() == 1
-    assert models.Theme.objects.count() == 1
+    assert models.ConsultationResponse.objects.count() >= 1
+    assert models.Section.objects.count() >= 1
+    assert models.Question.objects.count() >= 1
+    assert models.Answer.objects.count() >= 1
+    assert models.Theme.objects.count() >= 1
 
     consultation.delete()
 

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -6,48 +6,21 @@ from consultation_analyser.consultations.views import filters
 
 
 def set_up_for_filters():
-    consultation = factories.ConsultationFactory()
-    consultation_response = factories.ConsultationResponseFactory(consultation=consultation)
-    section = factories.SectionFactory(consultation=consultation)
-    question = factories.QuestionFactory(
-        section=section,
-    )
-    processing_run = factories.ProcessingRunFactory(consultation=consultation)
-    topic_model_meta = factories.TopicModelMetadataFactory()
-    theme1 = factories.ThemeFactory(
-        topic_keywords=["dog", "puppy"],
-        processing_run=processing_run,
-        topic_model_metadata=topic_model_meta,
-    )
-    theme2 = factories.ThemeFactory(
-        topic_keywords=["cat", "kitten"],
-        processing_run=processing_run,
-        topic_model_metadata=topic_model_meta,
-    )
-    answer = factories.AnswerFactory(
-        question=question,
-        free_text="We love dogs.",
-        consultation_response=consultation_response,
-    )
-    answer.themes.add(theme1)
-    answer = factories.AnswerFactory(
-        question=question,
-        free_text="We like cats not dogs.",
-        consultation_response=consultation_response,
-    )
-    answer.themes.add(theme2)
-    answer = factories.AnswerFactory(
-        question=question,
-        free_text="We love cats.",
-        consultation_response=consultation_response,
-    )
-    answer.themes.add(theme2)
-    answer = factories.AnswerFactory(
-        question=question,
-        free_text=None,
-        consultation_response=consultation_response,
-    )
-    answer.themes.add(theme2)
+    consultation_builder = factories.ConsultationBuilder()
+    question = consultation_builder.add_question()
+
+    theme1 = consultation_builder.add_theme(topic_keywords=["dog", "puppy"])
+    theme2 = consultation_builder.add_theme(topic_keywords=["cat", "kitten"])
+
+    for answer, theme in [
+        ["We love dogs.", theme1],
+        ["We like cats not dogs", theme2],
+        ["We love cats", theme2],
+        [None, theme2],
+    ]:
+        a = consultation_builder.add_answer(question, free_text=answer)
+        a.themes.add(theme)
+
     return question
 
 

--- a/tests/unit/test_generate_dummy_data.py
+++ b/tests/unit/test_generate_dummy_data.py
@@ -18,9 +18,6 @@ def test_a_consultation_is_generated(settings):
     assert Question.objects.count() == 10
     assert Answer.objects.count() >= 100
 
-    qs = Answer.objects.filter(themes__is_outlier=True)
-    assert qs.exists()
-
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("environment", ["prod"])

--- a/tests/unit/test_llm_summariser_functions.py
+++ b/tests/unit/test_llm_summariser_functions.py
@@ -4,14 +4,7 @@ import pytest
 import tiktoken
 
 from consultation_analyser.factories import (
-    AnswerFactory,
-    ConsultationFactory,
-    ConsultationResponseFactory,
-    ProcessingRunFactory,
-    QuestionFactory,
-    SectionFactory,
-    ThemeFactory,
-    TopicModelMetadataFactory,
+    ConsultationBuilder,
 )
 from consultation_analyser.pipeline.backends.langchain_llm_backend import (
     get_random_sample_of_responses_for_theme,
@@ -21,53 +14,43 @@ from consultation_analyser.pipeline.backends.langchain_llm_backend import (
 @pytest.mark.django_db
 def test_get_random_sample_of_responses_for_theme():
     encoding = tiktoken.get_encoding("cl100k_base")  # Use arbitrary encoding model
-    consultation = ConsultationFactory()
-    consultation_response = ConsultationResponseFactory(consultation=consultation)
-    section = SectionFactory(consultation=consultation)
-    question = QuestionFactory(has_free_text=True, section=section)
-    processing_run = ProcessingRunFactory(consultation=consultation)
-    theme = ThemeFactory(processing_run=processing_run)
-    text = "Here are my strong opinions on chocolate. I love KitKats."  # 14 tokens
-    answer = AnswerFactory(
-        question=question, free_text=text, consultation_response=consultation_response
-    )
-    answer.themes.add(theme)
-    combined_responses = get_random_sample_of_responses_for_theme(
-        theme, encoding=encoding, max_tokens=40
-    )
-    assert combined_responses.strip() == text
+    consultation_builder = ConsultationBuilder()
+    question = consultation_builder.add_question()
 
-    # Now test that we combine multiple responses but don't exceed limit.
-    for i in range(3):
-        answer = AnswerFactory(
-            question=question,
-            free_text=text,
-            consultation_response=consultation_response,
-        )
-        answer.themes.add(theme)
+    answer_text = "Here are my strong opinions on chocolate. I love KitKats."  # 14 tokens
+
+    answer = consultation_builder.add_answer(question, free_text=answer_text)
+    theme = consultation_builder.add_theme()
+
+    answer.themes.add(theme)
+
     combined_responses = get_random_sample_of_responses_for_theme(
         theme, encoding=encoding, max_tokens=40
     )
+    assert combined_responses.strip() == answer_text
+
+    for i in range(3):
+        answer = consultation_builder.add_answer(question, free_text=answer_text)
+        answer.themes.add(theme)
+
+    combined_responses = get_random_sample_of_responses_for_theme(
+        theme, encoding=encoding, max_tokens=40
+    )
+
     assert len(encoding.encode(combined_responses)) < 30, combined_responses
-    assert combined_responses.count(text) > 1, combined_responses
+    assert combined_responses.count(answer_text) > 1, combined_responses
 
 
 @pytest.mark.django_db
 def test_get_random_sample_of_responses_for_theme_does_not_repeat():
     encoding = tiktoken.get_encoding("cl100k_base")  # Use arbitrary encoding model
-    consultation = ConsultationFactory()
-    consultation_response = ConsultationResponseFactory(consultation=consultation)
-    section = SectionFactory(consultation=consultation)
-    question = QuestionFactory(has_free_text=True, section=section)
-    processing_run = ProcessingRunFactory(consultation=consultation)
-    topic_model_meta = TopicModelMetadataFactory()
-    theme = ThemeFactory(processing_run=processing_run, topic_model_metadata=topic_model_meta)
+    consultation_builder = ConsultationBuilder()
+    question = consultation_builder.add_question()
+    theme = consultation_builder.add_theme()
 
     answers = list(string.ascii_lowercase)  # get 27 distinct answers
     for a in answers:
-        answer = AnswerFactory(
-            question=question, free_text=a, consultation_response=consultation_response
-        )
+        answer = consultation_builder.add_answer(question, free_text=a)
         answer.themes.add(theme)
 
     combined_responses = get_random_sample_of_responses_for_theme(

--- a/tests/views/test_consultation_scoping.py
+++ b/tests/views/test_consultation_scoping.py
@@ -9,7 +9,7 @@ from consultation_analyser.factories import ConsultationFactory, UserFactory
 @pytest.mark.django_db
 def test_get_consultation_we_own(client):
     user = UserFactory()
-    consultation_we_own = ConsultationFactory(user=user, with_themes=True)
+    consultation_we_own = ConsultationFactory(user=user)
     client.force_login(user)
     response = client.get(f"/consultations/{consultation_we_own.slug}/")
     assert response.status_code == 200


### PR DESCRIPTION
## Context

🏭 🏭 🏭 🏭 🏭 

The factories were magical & confusing. The dummy data was not quite as good as it could be.

## Changes proposed in this pull request

- Stop using magic `with_` callbacks in factories and remove them.
- Introduce monolithic `ConsultationWithThemes` factory which is useful in 3 places and `ConsultationWithAnswers` factory which is also useful in 3 places, allowing us to get stock Consultation in either state with a single line of code.
- For more granular use cases (and used in 8 places) introduce `ConsultationBuilder`. This allows us to add questions/answers/themes etc to a test consultation without worrying about hooking up all the bits of state each part needs.

BONUS:

- while using `ConsultationBuilder` to clean up the dummy data generator, fix a bug whereby we could generate multiple answers to the same question for the same `ConsultationResponse`
- cause topics created by `DummyTopicBackend` to clump up a bit, i.e. not be 1/1 with answers

## Guidance to review

This should all be better and more readable I hope! Have a look at some tests and the dummy_data routine to see the bits and pieces in action.

## Link to JIRA ticket

N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo