### PR TITLE
Bugfix/Don't crash when not-logged-in user visits a consultation

### DIFF
--- a/consultation_analyser/consultations/views/decorators.py
+++ b/consultation_analyser/consultations/views/decorators.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from .. import models
@@ -6,6 +7,9 @@ from .. import models
 def user_can_see_consultation(view_function):
     def decorator(request, *args, **kwargs):
         slug = kwargs.get("consultation_slug")
+
+        if not request.user.is_authenticated:
+            raise Http404()
 
         # will kick out users by throwing a 404 if they don't own the consultation
         get_object_or_404(models.Consultation.objects.filter(slug=slug, users__in=[request.user]))

--- a/tests/integration/test_user_can_see_consultations.py
+++ b/tests/integration/test_user_can_see_consultations.py
@@ -24,3 +24,12 @@ def test_user_can_see_consultations(django_app):
 
     # then i should see the new consultation
     assert "My First Consultation" in landing_page
+
+
+@pytest.mark.django_db
+def test_logged_out_user_sees_404s(django_app):
+    ConsultationFactory(slug="whatever")
+
+    returned_page = django_app.get("/consultations/whatever/", expect_errors=True)
+
+    assert "Page not found" in returned_page


### PR DESCRIPTION
## Context

https://i-dot-ai.sentry.io/issues/5583860195/?environment=preprod&project=4507153305239552&query=&referrer=issue-stream&statsPeriod=1h&stream_index=0
