### PR TITLE
Accurately specify python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Populate `.env` by copying `.env.example` and filling in required values.
 
 ### Python
 
-Ensure you have `python >= 3.12`, `poetry` and `npm` installed, then run `poetry install`.
+Ensure you have `python 3.12.3`, `poetry` and `npm` installed, then run `poetry install`.
 
 ### Database setup
 


### PR DESCRIPTION
## Context

`README.md` was slightly inconsistent with `pyproject.toml`

## Changes proposed in this pull request

📐 📐 📐 

