### PR TITLE
Increase default number of responses to make theme generation easier.

### DIFF
--- a/consultation_analyser/consultations/dummy_data.py
+++ b/consultation_analyser/consultations/dummy_data.py
@@ -8,7 +8,7 @@ from consultation_analyser.factories import (
 from consultation_analyser.hosting_environment import HostingEnvironment
 
 
-def create_dummy_data(responses=10, number_questions=10, **options):
+def create_dummy_data(responses=20, number_questions=10, **options):
     if number_questions > 10:
         raise RuntimeError("You can't have more than 10 questions")
     if HostingEnvironment.is_production():


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Since the changes to factories - theme generation fails more often (I think due to the way responses are created?). Increase the number of responses in dummy data which means theme generation fails less frequently.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I have checked that running dummy data (1) generates expected number of responses and (2) theme generation doesn't fail. Tests are passing.

## Link to JIRA ticket

<!-- e.g. https://technologyprogramme.atlassian.net/jira/software/c/projects/ER/boards/346?selectedIssue=ER-87 -->
N/A

## Things to check

- [X] I have added any new ENV vars in all deployed environments and updated the `.env.example` and `.env.test` files in the repo